### PR TITLE
Copy scripts to installation path, to resolve #152

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ build:
 
 	@echo "\n=== Installing DeepDive... ==="
 	make -C target/pack/ install ; 
+	# copy utils scripts, to solve path issue
+	cp -r util/* ${HOME}/local/deepdive/current
 
 	@echo "\n=== Verifying installation... ==="
 	@if [ -f ${HOME}/local/bin/deepdive ]; then \


### PR DESCRIPTION
To allow deepdive to run from anywhere
#### path issue

I agree `deepdive` should be able to run anywhere. And I think of three approaches:
1. A naive approach is, when installing, include `DEEPDIVE_HOME` in the launch script. and upon execution change directory to `DEEPDIVE_HOME` in it. In this way, the assumption can be kept.
2. Or when referring to scripts, do it like `python $DEEPDIVE_HOME/util/tobinary.py`. But I think keeping the executable and scripts in two places isn't neat.
3. Another way is to copy the `util/*` scripts to installation. I think this is clear, and won't interfere development / deployment.

What do you think?
