### PR TITLE
Fixed json_extractor to include null values in extractor input

### DIFF
--- a/src/main/scala/org/deepdive/DeepDive.scala
+++ b/src/main/scala/org/deepdive/DeepDive.scala
@@ -120,7 +120,12 @@ object DeepDive extends Logging {
       
 
     // Create a default pipeline that executes all tasks
-    val defaultPipeline = Pipeline("_default", allTasks.map(_.id).toSet)
+    val defaultPipeline = Pipeline("_default", 
+      activeFactors.size match {
+        // If no factors are active, do not run inference tasks
+        case 0 => allTasks.map(_.id).toSet -- Set("inference_grounding", "inference", "calibration")
+        case _ => allTasks.map(_.id).toSet
+      })
 
     // Create a pipeline that runs only from learning
     val relearnPipeline = Pipeline("_relearn", Set("inference", "calibration", "report", "shutdown"))

--- a/src/main/scala/org/deepdive/extraction/datastore/JdbcExtractionDataStore.scala
+++ b/src/main/scala/org/deepdive/extraction/datastore/JdbcExtractionDataStore.scala
@@ -48,7 +48,8 @@ trait JdbcExtractionDataStore extends ExtractionDataStore[JsObject] with Logging
                   val label = metadata.getColumnLabel(i)
                   val data = unwrapSQLType(rs.getObject(i))
                   (label, data)
-                }.filter(_._2 != null).toMap
+                }//.filter(_._2 != null) // do not filter out null values
+                .toMap
               }
             }
             block(resultIter)

--- a/src/test/scala/unit/extraction/PostgresExtractionDataStoreSpec.scala
+++ b/src/test/scala/unit/extraction/PostgresExtractionDataStoreSpec.scala
@@ -110,6 +110,7 @@ class PostgresExtractionDataStoreSpec extends FunSpec with BeforeAndAfter
       assert(result.head.asInstanceOf[JsObject].value == Map[String, JsValue](
         "id" -> JsNumber(1),
         "key" -> JsNumber(1),
+        "some_null" -> JsNull,
         "some_text" -> JsString("Hello"),
         "some_boolean" -> JsBoolean(true),
         "some_double" -> JsNumber(1.0),
@@ -142,7 +143,7 @@ class PostgresExtractionDataStoreSpec extends FunSpec with BeforeAndAfter
 
   describe ("Writing to the data store") {
 
-    it("should work") {
+    it("should work with null values") {
       val testRow = JsObject(Map[String, JsValue](
         "key" -> JsNumber(100),
         "some_text" -> JsString("I am sample text."),
@@ -154,12 +155,12 @@ class PostgresExtractionDataStoreSpec extends FunSpec with BeforeAndAfter
       dataStore.addBatch(List(testRow).iterator, "datatype_test")
       val result = dataStore.queryAsJson("SELECT * from datatype_test")(_.toList)
       val resultFields = result.head.fields
-      val expectedResult = testRow.value.filterKeys(_ != "some_null")
+      val expectedResult = testRow.value
       assert(resultFields.toMap.filterKeys(_ != "id").values.toSet == expectedResult.values.toSet) 
     }
   }
 
-  it("should correctly insert arrays with escape characters") {
+  it("should correctly handle null values, and insert arrays with escape characters") {
     val jsonArr = Json.parse("""["dobj@","@prep_}as","dobj\"@nsubj","dobj@prep_\\","dobj@prep_to"]""")
     val testRow = JsObject(Map[String, JsValue](
         "key" -> JsNull,
@@ -173,7 +174,7 @@ class PostgresExtractionDataStoreSpec extends FunSpec with BeforeAndAfter
     val result = dataStore.queryAsJson("SELECT * from datatype_test")(_.toList)
     val resultFields = result.head.fields
     val expectedResult = testRow.value
-    assert(resultFields.toMap.filterKeys(_ != "id") == Map("some_array" -> jsonArr)) 
+    assert(resultFields.toMap.filterKeys(_ != "id").values.toSet == expectedResult.values.toSet)
   }
 }
   


### PR DESCRIPTION
We used to intentionally eliminate fields in a row where value
is null in JSON extractor input. Now we want to include these
fields with null values.

For example, for a table a(x, y), if a row is (1, NULL), the
json_extractor input for this row used to be {"x": 1}. Now our input is
{"x": 1, "y": null}.

**Include another bug fix: in default pipeline, when no factors are active, do not run the sampler.**

Previously when we specify no factors in the pipeline, the sampler won't run. But when we specify no pipeline, the sampler will run even there are no factors. Now we fix it.
