### PR TITLE
Drop a temporary column in grounding if it exists

### DIFF
--- a/src/main/scala/org/deepdive/inference/datastore/SQLInferenceDataStore.scala
+++ b/src/main/scala/org/deepdive/inference/datastore/SQLInferenceDataStore.scala
@@ -561,8 +561,15 @@ trait SQLInferenceDataStore extends InferenceDataStore with Logging {
       // - a variable is an evidence if it has initial value and it is not holdout
       val variableTypeColumn = "__dd_variable_type__"
       // Dropping this column if it exists, in case the last grounding is not successful
+      try {
+        // GP (psql8.2) do not support DROP COLUMN IF EXISTS syntax.
+        execute(s"""ALTER TABLE ${relation} DROP COLUMN ${variableTypeColumn} CASCADE;""")
+      } catch {
+        case exception : Throwable =>
+          // allow any type of exception here
+      }
+        
       execute(s"""
-        ALTER TABLE ${relation} DROP COLUMN IF EXISTS ${variableTypeColumn} CASCADE;
         ALTER TABLE ${relation} ADD COLUMN ${variableTypeColumn} int;
         """)
       execute(s"""


### PR DESCRIPTION
During grounding, the 'dd_variable_type' column is added to the tables
involved in inference rules. If for some reason grounding gets killed,
the column is still there, so when running the application again, it
fails during grounding because the column already exists, so the
following query will fail:
'ALTER TABLE some_variable_table ADD COLUMN dd_variable_type int'

Now we try to remove the column before adding it.
