### PR TITLE
Removed unused coref code in NLP extractor

### DIFF
--- a/examples/nlp_extractor/src/main/scala/DocumentParser.scala
+++ b/examples/nlp_extractor/src/main/scala/DocumentParser.scala
@@ -10,7 +10,7 @@ import edu.stanford.nlp.pipeline._
 import edu.stanford.nlp.util._
 import edu.stanford.nlp.ling.CoreAnnotations._
 import edu.stanford.nlp.semgraph.SemanticGraphCoreAnnotations.CollapsedCCProcessedDependenciesAnnotation
-import edu.stanford.nlp.dcoref.CorefCoreAnnotations.CorefChainAnnotation
+// import edu.stanford.nlp.dcoref.CorefCoreAnnotations.CorefChainAnnotation
 import scala.collection.JavaConversions._
 import java.io.{StringReader, StringWriter, PrintWriter}
 import java.util.Properties
@@ -24,7 +24,7 @@ class DocumentParser(props: Properties) {
 
     val document = new Annotation(doc)
     pipeline.annotate(document)
-    val dcoref = document.get(classOf[CorefChainAnnotation])
+    // val dcoref = document.get(classOf[CorefChainAnnotation])
     val sentences = document.get(classOf[SentencesAnnotation])
 
     val sentenceResults = sentences.zipWithIndex.map { case(sentence, sentIdx) =>

--- a/examples/nlp_extractor/src/main/scala/DocumentParser.scala
+++ b/examples/nlp_extractor/src/main/scala/DocumentParser.scala
@@ -10,11 +10,12 @@ import edu.stanford.nlp.pipeline._
 import edu.stanford.nlp.util._
 import edu.stanford.nlp.ling.CoreAnnotations._
 import edu.stanford.nlp.semgraph.SemanticGraphCoreAnnotations.CollapsedCCProcessedDependenciesAnnotation
-// import edu.stanford.nlp.dcoref.CorefCoreAnnotations.CorefChainAnnotation
 import scala.collection.JavaConversions._
 import java.io.{StringReader, StringWriter, PrintWriter}
 import java.util.Properties
 
+// Future usage: coreference resolution
+// import edu.stanford.nlp.dcoref.CorefCoreAnnotations.CorefChainAnnotation
 
 class DocumentParser(props: Properties) {
 
@@ -24,6 +25,7 @@ class DocumentParser(props: Properties) {
 
     val document = new Annotation(doc)
     pipeline.annotate(document)
+    // Future usage: coreference resolution
     // val dcoref = document.get(classOf[CorefChainAnnotation])
     val sentences = document.get(classOf[SentencesAnnotation])
 

--- a/examples/nlp_extractor/src/main/scala/Main.scala
+++ b/examples/nlp_extractor/src/main/scala/Main.scala
@@ -35,7 +35,7 @@ object Main extends App {
 
   // Configuration has been parsed, execute the Document parser
   val props = new Properties()
-  props.put("annotators", "tokenize, cleanxml, ssplit, pos, lemma, ner, parse, dcoref")
+  props.put("annotators", "tokenize, cleanxml, ssplit, pos, lemma, ner, parse")
   props.put("parse.maxlen", conf.maxSentenceLength)
   props.put("threads", conf.numThreads)
   val dp = new DocumentParser(props)


### PR DESCRIPTION
Currently in nlp_extractor there is an additional step to extract
coreference which slows down the progress, but the coref data is unused
in the output table. Removed these steps to speed up the progress.

In the future, we should add coreference exraction into the NLP extractor.