### PR TITLE
Fix mysql command line password option

### DIFF
--- a/src/main/scala/org/deepdive/helpers/Helpers.scala
+++ b/src/main/scala/org/deepdive/helpers/Helpers.scala
@@ -66,7 +66,7 @@ object Helpers extends Logging {
         case Mysql => dbpassword match { // see if password is empty
           case null => s" -u ${dbuser} "
           case "" => s" -u ${dbuser} "
-          case _ => s" -u ${dbuser} -p=${dbpassword}"
+          case _ => s" -u ${dbuser} -p${dbpassword}"
         }
       }
     }


### PR DESCRIPTION
The mysql password option is either "--password[=password]" or "-p[password]".  If you use the short option form (-p), you cannot have a space between the option and the password.