### PR TITLE
removed relative setting of APP_HOME and DEEPDIVE_HOME in tutorial files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out/
 out/
 hsql:*
 *.pyc
+*.swp
 /lib/dw_mac
 /lib/dw_linux
 .cache
@@ -22,4 +23,4 @@ examples/tutorial_example/*/experiment-reports/latest
 */dd-out
 examples/spouse_example/data/sentences_dump_large.csv
 examples/spouse_example/data/spouses.tsv
-
+*/__MACOSX/*

--- a/examples/tutorial_example/step1-basic/braindump.conf
+++ b/examples/tutorial_example/step1-basic/braindump.conf
@@ -1,4 +1,3 @@
-
 ########## Conventions. Do not recommend to change. ###########
 
 # Set the utility files dir
@@ -10,16 +9,12 @@ export REPORT_DIR="$WORKING_DIR/experiment-reports"
 
 ########## User-specified configurations ###########
 
+# Assumes that $DEEPDIVE_DIR and $APP_HOME are already set
+
 # Directories
 
-# Use absolute path if possible.
-# Avoid using "pwd" or "dirname $0", they don't work properly.
-# $WORKING_DIR is set to be the directory where braindump is running. 
-# (the directory that contains braindump.conf)
-export APP_HOME=$WORKING_DIR
-
 # Specify deepdive out directory (DEEPDIVE_HOME/out)
-export DD_OUTPUT_DIR=$WORKING_DIR/../../../out
+export DD_OUTPUT_DIR=$DEEPDIVE_DIR/out
 
 # Database Configuration
 export DBNAME=deepdive_spouse

--- a/examples/tutorial_example/step1-basic/run.sh
+++ b/examples/tutorial_example/step1-basic/run.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+# Assumes that $APP_HOME and $DEEPDIVE_HOME are set
+
 # Check the data files
 if ! [ -d data ] \
   || ! [ -f data/spouses.tsv ] \
@@ -9,9 +11,6 @@ if ! [ -d data ] \
   echo "ERROR: Data files do not exist. You should download the data from http://i.stanford.edu/hazy/deepdive-tutorial-data.zip, and extract files to data/ directory."
   exit 1;
 fi
-
-export APP_HOME=`cd $(dirname $0)/; pwd`
-export DEEPDIVE_HOME=`cd $(dirname $0)/../../../; pwd`
 
 # Database Configuration
 export DBNAME=deepdive_spouse


### PR DESCRIPTION
The tutorial instructs the user to set $DEEPDIVE_HOME and $APP_HOME early on. It references these variables in the command line.

When run.sh and braindump.conf rewrite the environment variables, it uses relative paths, so forces user to run from a specific directory. Also the number of "../" is wrong for the app directory because it is set for the example directory, which has an extra nested level.

I think it makes more sense to ask the user to set these variables for themselves early on.