### PR TITLE
Shorter name for unloading extractor queries

### DIFF
--- a/src/main/scala/org/deepdive/extraction/ExtractorRunner.scala
+++ b/src/main/scala/org/deepdive/extraction/ExtractorRunner.scala
@@ -396,7 +396,7 @@ class ExtractorRunner(dataStore: JdbcDataStore, dbSettings: DbSettings) extends 
 
     // NEW: for mysqlimport compatibility, the file basename must be same as table name.
     val queryOutputFile = new File(queryOutputPath + s"${outputRel}.copy_query_${funcName}.tsv")
-    val gpFileName = s"${outputRel}_unload_${funcName}"
+    val gpFileName = s"${outputRel}_query_unload"
     val psqlFilePath = queryOutputFile.getAbsolutePath()
 
     // Get the actual dumped file 


### PR DESCRIPTION
Currently the extractor input query might have a too long name (>64 chars) which causes a bug in GP. Used a shorter name for unloading.

See https://github.com/HazyResearch/deepdive/commit/dfe749dc1b0ac36bf0087efaf502112dd1937bc8.