### PR TITLE
Removes the need for LD_LIBRARY_PATH settings for the sampler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ hsql:*
 *.pyc
 /lib/dw_mac
 /lib/dw_linux
+/util/sampler-dw
 .cache
 .classpath
 .idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN cd ~/deepdive && make
 RUN echo 'export PGPORT=$DB_PORT_5432_TCP_PORT' >> ~/.bashrc && echo 'export PGHOST=$DB_PORT_5432_TCP_ADDR' >> ~/.bashrc && \
     echo 'export PGPASSWORD=' >> ~/.bashrc && echo 'export PGUSER=gpadmin' >> ~/.bashrc && \
     echo 'export DEEPDIVE_HOME=~/deepdive' >> ~/.bashrc && \
-    echo 'export LD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_linux/lib:$DEEPDIVE_HOME/sbt:$DEEPDIVE_HOME/lib/dw_linux/lib64' >> ~/.bashrc && \
     echo 'export PATH=~/deepdive/sbt:$PATH' >> ~/.bashrc && \
     echo 'echo "DeepDive needs a database connection to run and is waiting for the DB to finish initializing. After it finishes, the shell will return control to you."' >> ~/.bashrc && \
     echo 'while true; do' >> ~/.bashrc && \

--- a/doc/doc/basics/installation.md
+++ b/doc/doc/basics/installation.md
@@ -104,15 +104,12 @@ On Mac:
 
 ```bash
 export DEEPDIVE_HOME=[your path to install deepdive]
-export LD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_mac/lib/protobuf/lib:$DEEPDIVE_HOME/lib/dw_mac/lib
-export DYLD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_mac
 ```
 
 On Linux:
 
 ```bash
 export DEEPDIVE_HOME=[your path to install deepdive]
-export LD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_linux/lib:$DEEPDIVE_HOME/lib/dw_linux/lib64
 ```
 
 (The set of environmental variable `DEEPDIVE_HOME` is optional. If not set, DeepDive will assume that `DEEPDIVE_HOME` is current directory.)

--- a/lib/dw_extract.sh
+++ b/lib/dw_extract.sh
@@ -10,11 +10,13 @@ case $(uname) in
     [ -d dw_mac ] ||
       ditto -xk dw_mac.zip .  # XXX ditto handles .zip better on OS X
       # unzip dw_mac.zip
+    ln -sfnv sampler-dw-mac.sh ../util/sampler-dw
     ;;
 
   Linux*)
     [ -d dw_linux ] ||
       unzip dw_linux.zip
+    ln -sfnv sampler-dw-linux.sh ../util/sampler-dw
     ;;
 
   *)

--- a/src/main/scala/org/deepdive/settings/SettingsParser.scala
+++ b/src/main/scala/org/deepdive/settings/SettingsParser.scala
@@ -213,15 +213,7 @@ object SettingsParser extends Logging {
 
     // Parse Default sampler command based on mac / linux
     val samplerCmd = samplingConfig.getString("sampler_cmd") match {
-      case "__DEFAULT__" =>
-        val osname = System.getProperty("os.name")
-        log.info(s"Detected OS: ${osname}")
-        if (osname.startsWith("Linux")) {
-          s"${Context.deepdiveHome}/util/sampler-dw-linux"
-        }
-        else {
-          s"${Context.deepdiveHome}/util/sampler-dw-mac"
-        }
+      case "__DEFAULT__" => s"${Context.deepdiveHome}/util/sampler-dw"
       case _ => samplingConfig.getString("sampler_cmd")
     }
 

--- a/src/test/scala/unit/inference/SamplerSpec.scala
+++ b/src/test/scala/unit/inference/SamplerSpec.scala
@@ -17,10 +17,6 @@ class SamplerSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSe
   val edgesFile = getClass.getResource("/inference/binary_factor_graph/edges").getFile()
   val metaFile = getClass.getResource("/inference/binary_factor_graph/meta.csv").getFile()
 
-  var samplerCmd = "util/sampler-dw-mac"
-  val osname = System.getProperty("os.name")
-  if (osname.startsWith("Linux")) {
-    samplerCmd = "util/sampler-dw-linux"
-  }
+  var samplerCmd = "util/sampler-dw"
 }
 

--- a/test.sh
+++ b/test.sh
@@ -1,24 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# FIXME this LD_LIBRARY_PATH config for sampler that plagues every part of our code as well as users' application code should be completely encapsulated within a wrapper command.
-# XXX For now, there's no easy way to unbreak the tests other than duplicating this everywhere.
-export DEEPDIVE_HOME=$(cd "$(dirname "$0")" && pwd)
-case $(uname) in
-  Darwin)
-    export LD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_mac/lib/protobuf/lib:$DEEPDIVE_HOME/lib/dw_mac/lib:$LD_LIBRARY_PATH
-    export DYLD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_mac:$DYLD_LIBRARY_PATH
-    ;;
-
-  Linux*)
-    export LD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_linux/lib:$DEEPDIVE_HOME/lib/dw_linux/lib64:$DEEPDIVE_HOME/lib/dw_linux/lib/numactl-2.0.9/:$LD_LIBRARY_PATH
-    ;;
-
-  *)
-    echo >&2 "$(uname): Unsupported OS"
-    false
-esac
-
 # uncompress all test and example data
 echo "Preparing test data..."
 examples/spouse_example/prepare_data.sh

--- a/test/test_gp.sh
+++ b/test/test_gp.sh
@@ -34,23 +34,6 @@ gpfdist -d $GPPATH -p $GPPORT &
 gpfdist_pid=$!
 trap "kill $gpfdist_pid" EXIT
 
-cd $DEEPDIVE_HOME/lib
-
-case $(uname) in
-  Darwin)
-    export LD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_mac/lib/protobuf/lib:$DEEPDIVE_HOME/lib/dw_mac/lib:$LD_LIBRARY_PATH
-    export DYLD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_mac:$DYLD_LIBRARY_PATH
-    ;;
-
-  Linux*)
-    export LD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_linux/lib:$DEEPDIVE_HOME/lib/dw_linux/lib64:$DEEPDIVE_HOME/lib/dw_linux/lib/numactl-2.0.9/:$LD_LIBRARY_PATH
-    ;;
-
-  *)
-    echo >&2 "$(uname): Unsupported OS"
-    false
-esac
-
 cd $DEEPDIVE_HOME
 
 # Create test database

--- a/test/test_mysql.sh
+++ b/test/test_mysql.sh
@@ -24,23 +24,6 @@ export DEEPDIVE_HOME=`cd $(dirname $0)/../; pwd`
 # This env var specifies system under test
 export DEEPDIVE_TEST_ENV="mysql"
 
-cd $DEEPDIVE_HOME/lib
-
-case $(uname) in
-  Darwin)
-    export LD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_mac/lib/protobuf/lib:$DEEPDIVE_HOME/lib/dw_mac/lib:$LD_LIBRARY_PATH
-    export DYLD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_mac:$DYLD_LIBRARY_PATH
-    ;;
-
-  Linux*)
-    export LD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_linux/lib:$DEEPDIVE_HOME/lib/dw_linux/lib64:$DEEPDIVE_HOME/lib/dw_linux/lib/numactl-2.0.9/:$LD_LIBRARY_PATH
-    ;;
-
-  *)
-    echo >&2 "$(uname): Unsupported OS"
-    false
-esac
-
 ##### unit tests have not been ported. Run integration tests (spouse example )instead ####
 cd $DEEPDIVE_HOME
 

--- a/test/test_psql.sh
+++ b/test/test_psql.sh
@@ -27,23 +27,6 @@ export DEEPDIVE_ACTIVE_INCREMENTAL_VARIABLES="r1"
 export DEEPDIVE_ACTIVE_INCREMENTAL_RULES="testFactor"
 export BASEDIR=$DEEPDIVE_HOME/out
 
-cd $DEEPDIVE_HOME/lib
-
-case $(uname) in
-  Darwin)
-    export LD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_mac/lib/protobuf/lib:$DEEPDIVE_HOME/lib/dw_mac/lib:$LD_LIBRARY_PATH
-    export DYLD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_mac:$DYLD_LIBRARY_PATH
-    ;;
-
-  Linux*)
-    export LD_LIBRARY_PATH=$DEEPDIVE_HOME/lib/dw_linux/lib:$DEEPDIVE_HOME/lib/dw_linux/lib64:$DEEPDIVE_HOME/lib/dw_linux/lib/numactl-2.0.9/:$LD_LIBRARY_PATH
-    ;;
-
-  *)
-    echo >&2 "$(uname): Unsupported OS"
-    false
-esac
-
 cd $DEEPDIVE_HOME
 
 # Create test database

--- a/util/sampler-dw-linux.sh
+++ b/util/sampler-dw-linux.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eu
+d=${0%/*}
+export LD_LIBRARY_PATH="$d"/../lib/dw_linux/lib:"$d"/../lib/dw_linux/lib64:"$d"/../lib/dw_linux/lib/numactl-2.0.9${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+exec "$0"-linux "$@"

--- a/util/sampler-dw-mac.sh
+++ b/util/sampler-dw-mac.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eu
+d=${0%/*}
+export LD_LIBRARY_PATH="$d"/../lib/dw_mac/lib/protobuf/lib:"$d"/../lib/dw_mac/lib"${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH="$d"/../lib/dw_mac"${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+exec "$0"-mac "$@"


### PR DESCRIPTION
Setting correct `LD_LIBRARY_PATH` environment has been a huge headache
for our users, especially when DeepDive is used against Greenplum.  At
least the setting for sampler is now completely taken care by a script
that wraps the sampler executable.  The script uses a uniform name
`util/sampler-dw` across different OS, hence no need for OS detection in
Scala.  At build time the correct script is symlinked with that name.