### PR TITLE
Adds deepdive help command and documentation

### DIFF
--- a/doc/doc/advanced/deepdiveapp.md
+++ b/doc/doc/advanced/deepdiveapp.md
@@ -49,6 +49,11 @@ A DeepDive application is a directory that contains the following files and dire
 There are several operations that are frequently performed on a DeepDive application.
 Any of the following command can be run under any subdirectory of a DeepDive application to perform a certain operation.
 
+To see all options for each command, such as specifying alternative configuration file for running, see the online help message with the `deepdive help` command.  For example:
+```bash
+deepdive help run
+```
+
 ### Initializing Database
 
 ```bash

--- a/doc/doc/changelog/0.7.0-alpha.md
+++ b/doc/doc/changelog/0.7.0-alpha.md
@@ -4,7 +4,7 @@ layout: default
 
 # Changelog for Release 0.7.0-alpha (07/14/2015)
 
-* Provides a new command-line interface `deepdive` with a new [standard DeepDive application layout](http://deepdive.stanford.edu/doc/advanced/deepdiveapp.html).
+* Provides a new command-line interface `deepdive` with a new [standard DeepDive application layout][applayout].
     - No more installation/configuration complication: Users run everything through the only `deepdive` command, and everything *just works* in any environment.  The only possible failure mode is not being able to run `deepdive` command, e.g., by not setting up the `PATH` environment correctly.
     - No more pathname/environment clutter in apps: repeated settings for `DEEPDIVE_HOME`, `APP_HOME`, `PYTHONPATH`, `LD_LIBRARY_PATH`, `PGHOST`, `PGPORT`, ... in `run.sh` or `env.sh` or `env_local.sh` or `env_db.sh` or etc. are gone.  Path names (e.g., extractor udf) in `application.conf` are all relative to the application root, and brittle relative paths are no longer used in any of the examples.
     - Clear separation of app code from infrastructure code, as well as source code from object code: No more confusing of deepdive source tree with binary/executable/shared-library distribution or temporary/log/output directories.
@@ -25,3 +25,18 @@ layout: default
 
 * Includes the latest Mindbender with Dashboard GUI for producing summary reports after each DeepDive run and interactively analyzing data products.
 
+
+### Workaround for Old Style Applications
+
+To have an old style DeepDive applications run with this version, here's a small change you can try.
+You can replace your `sbt` or `deepdive` line in your `run.sh` script with the following `deepdive env java` command:
+
+```bash
+deepdive env java org.deepdive.Main -c application.conf -o output_dir
+```
+
+However, it is strongly recommended to upgrade to the new [standard layout][applayout] because more features and tools will rely on the app structure, and backward incompatible changes that break the following workaround can be introduced at any release in the future.
+
+
+
+[applayout]: http://deepdive.stanford.edu/doc/advanced/deepdiveapp.html

--- a/shell/deepdive
+++ b/shell/deepdive
@@ -59,21 +59,8 @@ shift $(($OPTIND - 1))
 # Process input arguments
 [ $# -gt 0 ] || {
     usage "$0" "No COMMAND given" || true
-    # enumerate available COMMANDs discoverable from PATH
     echo
-    echo "# Available COMMANDs are:"
-    IFS=:
-    tmp=$(mktemp -d "${TMPDIR:-/tmp}"/deepdive-usage.XXXXXXX)
-    trap 'rm -rf "$tmp"' EXIT
-    for path in $PATH; do
-        for exe in "$path"/deepdive-*; do
-            [ -x "$exe" ] || continue
-            usage "$exe" | head -1 | sed -n '/ -- / s/.* -- //p' >>"$tmp"/desc
-            cmd=${exe##*/deepdive-}
-            echo "deepdive $cmd  #"
-        done
-    done | column -t >"$tmp"/commands
-    paste "$tmp"/commands "$tmp"/desc
+    deepdive-help | sed -n '/^# Available COMMANDs/,$p'
     false
 }
 Cmd=$1; shift

--- a/shell/deepdive-help
+++ b/shell/deepdive-help
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# deepdive-help -- Shows help
+# > deepdive help [COMMAND]
+##
+# Author: Jaeho Shin <netj@cs.stanford.edu>
+# Created: 2015-07-30
+set -eu
+
+if [[ $# -gt 0 ]]; then
+    Cmd=$1; shift
+    exe=deepdive-"$Cmd"
+    if exePath=$(type -p "$exe"); then
+        exec usage "$exePath"
+    else
+        usage "$0" "$Cmd: invalid COMMAND" || true  # continue to enumerate available ones
+    fi
+else
+    usage "$0"
+fi
+
+# enumerate available COMMANDs discoverable from PATH
+echo
+echo "# Available COMMANDs are:"
+IFS=:
+tmp=$(mktemp -d "${TMPDIR:-/tmp}"/deepdive-usage.XXXXXXX)
+trap 'rm -rf "$tmp"' EXIT
+for path in $PATH; do
+    for exe in "$path"/deepdive-*; do
+        [ -x "$exe" ] || continue
+        usage "$exe" | head -1 | sed -n '/ -- / s/.* -- //p' >>"$tmp"/desc
+        cmd=${exe##*/deepdive-}
+        echo "deepdive $cmd  #"
+    done
+done | column -t >"$tmp"/commands
+paste "$tmp"/commands "$tmp"/desc

--- a/shell/usage
+++ b/shell/usage
@@ -26,6 +26,7 @@ ToolPath=$1; shift || usage "$0" "No TOOLPATH given"
 cat "$ToolPath" |
 sed -n "
 2,/^##$/ {
+    /^##$/q
     ${USAGE_TOOL_COMMAND:+$(printf \
         's#^\(\# [$>] \)%s #\\1%s #' \
         "${USAGE_TOOL_COMMAND//\#/\\\#}" \

--- a/stage.sh
+++ b/stage.sh
@@ -33,6 +33,7 @@ stage() {
 # DeepDive shell
 stage shell/deepdive                                              bin/
 stage shell/deepdive-version                                      util/
+stage shell/deepdive-help                                         util/
 stage shell/deepdive-env                                          util/
 stage shell/find-deepdive-app                                     util/
 stage shell/parse-url.sh                                          util/


### PR DESCRIPTION
for users to discover full command line interface options that are
already documented in each shell script.

Also documents a workaround for old style apps to at least run with the
new style in changelog.  Fixes #346.