### PR TITLE
Makes deepdive shell robust from user's old `$APP_HOME`

### DIFF
--- a/shell/deepdive
+++ b/shell/deepdive
@@ -50,7 +50,7 @@ fi
 # Process common options
 while getopts "C:" o; do
     case $o in
-        C) export APP_HOME=$OPTARG ;;
+        C) export DEEPDIVE_APP=$OPTARG ;;
     esac
 done
 shift $(($OPTIND - 1))

--- a/shell/deepdive-initdb
+++ b/shell/deepdive-initdb
@@ -5,9 +5,9 @@
 set -eu
 
 # find the current application
-APP_HOME=$(find-deepdive-app)
-export APP_HOME
-cd "$APP_HOME"
+DEEPDIVE_APP=$(find-deepdive-app)
+export DEEPDIVE_APP
+cd "$DEEPDIVE_APP"
 
 . load-db-driver.sh
 
@@ -25,5 +25,8 @@ if [[ -e schema.sql ]]; then
 fi
 
 # load the input data
-! [[ -x input/init.sh ]] ||
+! [[ -x input/init.sh ]] || {
+    # XXX set the legacy environment variables
+    export APP_HOME=$DEEPDIVE_APP
     input/init.sh "$@"
+}

--- a/shell/deepdive-run
+++ b/shell/deepdive-run
@@ -24,7 +24,7 @@ set -eu
 ddlogFiles=()
 while getopts "C:c:o:" o; do
     case $o in
-        C) APP_HOME=$OPTARG ;;
+        C) DEEPDIVE_APP=$OPTARG ;;
         c) DEEPDIVE_CONFIG=$OPTARG ;;
         o) DEEPDIVE_OUTPUT=$OPTARG ;;
         d) ddlogFiles+=("$OPTARG") ;;
@@ -39,10 +39,10 @@ Pipeline=
 }
 
 ## find the current application
-# either specified with -C option or via APP_HOME environment
-APP_HOME=$(find-deepdive-app)
-export APP_HOME
-cd "$APP_HOME"
+# either specified with -C option or via DEEPDIVE_APP environment
+DEEPDIVE_APP=$(find-deepdive-app)
+export DEEPDIVE_APP
+cd "$DEEPDIVE_APP"
 
 # find the configuration file for the application
 # defaults to deepdive.conf, which can be overriden via command-line option -c or DEEPDIVE_CONFIG environment
@@ -107,10 +107,12 @@ fullConfig=$run_dir/deepdive.conf
 
 } >"$fullConfig"
 
+# XXX set the legacy environment variables
+export APP_HOME=$DEEPDIVE_APP
 
 ## run DeepDive
 # JVM directly executes everything currently
-java org.deepdive.Main -c "$fullConfig" -o "$APP_HOME/$run_dir"
+java org.deepdive.Main -c "$fullConfig" -o "$DEEPDIVE_APP/$run_dir"
 
 # point to the run with LATEST symlink
 ln -sfn "$run_id" run/LATEST

--- a/shell/find-deepdive-app
+++ b/shell/find-deepdive-app
@@ -8,12 +8,12 @@ at_deepdive_app_root() {
     [[ ( -e app.ddlog || ( -e deepdive.conf && -e schema.sql ) ) && -e db.url ]]
 }
 
-if [[ -d "${APP_HOME:-}" ]]; then
-    cd "$APP_HOME"
+if [[ -d "${DEEPDIVE_APP:-}" ]]; then
+    cd "$DEEPDIVE_APP"
     if at_deepdive_app_root; then
-        echo "$APP_HOME"
+        echo "$DEEPDIVE_APP"
     else
-        error "$APP_HOME: Not a DeepDive application: deepdive.conf, db.url, and schema.sql should be all present"
+        error "$DEEPDIVE_APP: \$DEEPDIVE_APP does not point to a DeepDive application: deepdive.conf, db.url, and schema.sql should be all present"
     fi
 else
     while ! at_deepdive_app_root && [[ $PWD != / ]]; do
@@ -23,6 +23,6 @@ else
     if at_deepdive_app_root; then
         pwd
     else
-        error "Not inside a DeepDive application: deepdive.conf, db.url, and schema.sql should be all present in a parent directory"
+        error "$PWD: Not inside a DeepDive application: deepdive.conf, db.url, and schema.sql should be all present in a parent directory"
     fi
 fi

--- a/shell/load-db-driver.sh
+++ b/shell/load-db-driver.sh
@@ -10,9 +10,9 @@ eval "$(
 
 # parse URL for database
 url=${DEEPDIVE_DB_URL:-$(
-    APP_HOME=$(find-deepdive-app)
-    export APP_HOME
-    cat "$APP_HOME"/db.url
+    DEEPDIVE_APP=$(find-deepdive-app)
+    export DEEPDIVE_APP
+    cat "$DEEPDIVE_APP"/db.url
 )}
 
 # recognize the database type from the URL scheme


### PR DESCRIPTION
by using a new name `$DEEPDIVE_APP` and only setting the legacy environment variable, not reading it.

Some users set such variables in their shell or source the env.sh which can cause trouble.