### PR TITLE
Smart split for extractor input based on parallelism

### DIFF
--- a/src/main/scala/org/deepdive/extraction/ExtractorRunner.scala
+++ b/src/main/scala/org/deepdive/extraction/ExtractorRunner.scala
@@ -460,7 +460,7 @@ class ExtractorRunner(dataStore: JdbcDataStore, dbSettings: DbSettings) extends 
       Helpers.executeCmd(splitCmdByPar);
     } catch {
       case e: Throwable =>
-        log.debug(s"Split by number of chunks is not supported. Try to use batch size ${linesPerSplit} to split...") 
+        log.debug(s"Split by number of chunks is not supported. Try to use batch size ${linesPerSplit} to split...")
         executeScriptOrFail(splitCmd, taskSender)
     }
 

--- a/src/main/scala/org/deepdive/extraction/ExtractorRunner.scala
+++ b/src/main/scala/org/deepdive/extraction/ExtractorRunner.scala
@@ -450,7 +450,7 @@ class ExtractorRunner(dataStore: JdbcDataStore, dbSettings: DbSettings) extends 
     val splitPrefix = s"${actualDumpedPath}-"
     val linesPerSplit = task.extractor.inputBatchSize
     val maxParallel = task.extractor.parallelism
-    val splitNum = maxParallel * 10
+    val splitNum = maxParallel
     val splitCmdByPar = s"split -a 10 -n l/${splitNum} " + actualDumpedPath + s" ${splitPrefix}"
     val splitCmd = s"split -a 10 -l ${linesPerSplit} " + actualDumpedPath + s" ${splitPrefix}"
 

--- a/src/main/scala/org/deepdive/extraction/ExtractorRunner.scala
+++ b/src/main/scala/org/deepdive/extraction/ExtractorRunner.scala
@@ -449,12 +449,20 @@ class ExtractorRunner(dataStore: JdbcDataStore, dbSettings: DbSettings) extends 
     log.info(s"File dumped to ${actualDumpedPath}")
     val splitPrefix = s"${actualDumpedPath}-"
     val linesPerSplit = task.extractor.inputBatchSize
+    val maxParallel = task.extractor.parallelism
+    val splitNum = maxParallel * 10
+    val splitCmdByPar = s"split -a 10 -n l/${splitNum} " + actualDumpedPath + s" ${splitPrefix}"
     val splitCmd = s"split -a 10 -l ${linesPerSplit} " + actualDumpedPath + s" ${splitPrefix}"
 
     log.info(s"Executing split command...")
-    executeScriptOrFail(splitCmd, taskSender)
-
-    val maxParallel = task.extractor.parallelism
+    try {
+      // First try to split by parallelism. This is more scalable than specifying the input batch size.
+      Helpers.executeCmd(splitCmdByPar);
+    } catch {
+      case e: Throwable =>
+        log.debug(s"Split by number of chunks is not supported. Try to use batch size ${linesPerSplit} to split...") 
+        executeScriptOrFail(splitCmd, taskSender)
+    }
 
     // Note (msushkov): the extractor must take TSV as input and produce TSV as output
     val runCmd = s"touch '${fpath}/${fname}-'; " + // XXX make sure xargs gets at least one file to process


### PR DESCRIPTION
It has been a problem for users to set input_batch_size to split extractor input correctly. Too small chunk size will yield too many udf executions and many file copy operations, which can be slow. Too large chunk size will reduce parallelism to 1.

Splitting the extractor input by parallelism should be the way to go. In this version, it detects whether system supports "split -n" command which split files into given number of chunks. If not supported, it falls back to use input_batch_size.