### PR TITLE
SSL support

### DIFF
--- a/doc/doc/advanced/deepdiveapp.md
+++ b/doc/doc/advanced/deepdiveapp.md
@@ -17,8 +17,9 @@ A DeepDive application is a directory that contains the following files and dire
 
     A URL representing the database configuration is supposed to be stored in this file.
     For example, `postgresql://user:password@localhost:5432/database_name` can be the line stored in it.
-    SSL connection can be enabled by setting parameter `ssl` as true in the URL. More specially, parameter `sslfactory` allows user to specify which custom class to use for creating the SSLSocketFactory.
-    For example, the URL allows SSL connections to be made without validating the server's certificate is `postgresql://user:password@localhost:5432/database_name?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory`.
+    
+    [SSL connections for PostgreSQL](https://jdbc.postgresql.org/documentation/91/ssl.html) can be enabled by setting parameter `ssl` as true in the URL, e.g.,  `postgresql://user:password@localhost:5432/database_name?ssl=true`.
+    If you use a self-signed certificate, you may want to disable validation with an extra `sslfactory` parameter: `postgresql://user:password@localhost:5432/database_name?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory`.
 
 * `deepdive.conf`
 

--- a/doc/doc/advanced/deepdiveapp.md
+++ b/doc/doc/advanced/deepdiveapp.md
@@ -17,6 +17,8 @@ A DeepDive application is a directory that contains the following files and dire
 
     A URL representing the database configuration is supposed to be stored in this file.
     For example, `postgresql://user:password@localhost:5432/database_name` can be the line stored in it.
+    SSL connection can be specified in the URL by adding `?ssl=true` in the end.
+    For example, `postgresql://user:password@localhost:5432/database_name?ssl=true`.
 
 * `deepdive.conf`
 

--- a/shell/driver.postgresql/db-parse
+++ b/shell/driver.postgresql/db-parse
@@ -24,7 +24,7 @@ echo "DEEPDIVE_JDBC_DRIVER=org.postgresql.Driver"
 if [ ${ssl} = "true" ]; then
     echo "DEEPDIVE_JDBC_URL=jdbc:postgresql://$host${port:+:$port}/$dbname?ssl=true\&sslfactory=org.postgresql.ssl.NonValidatingFactory"
 else
-    echo "DEEPDIVE_JDBC_URL=jdbc:postgresql://$host${port:+:$port}/$dbname" 
+    echo "DEEPDIVE_JDBC_URL=jdbc:postgresql://$host${port:+:$port}/$dbname"
 fi
 echo "export DEEPDIVE_JDBC_DRIVER DEEPDIVE_JDBC_URL"
 

--- a/shell/driver.postgresql/db-parse
+++ b/shell/driver.postgresql/db-parse
@@ -21,7 +21,11 @@ echo "export DBHOST DBPORT DBUSER DBPASSWORD DBNAME"
 
 # more variables for Scala application.conf
 echo "DEEPDIVE_JDBC_DRIVER=org.postgresql.Driver"
-echo "DEEPDIVE_JDBC_URL=jdbc:postgresql://$host${port:+:$port}/$dbname"
+if [ ${ssl} = "true" ]; then
+    echo "DEEPDIVE_JDBC_URL=jdbc:postgresql://$host${port:+:$port}/$dbname?ssl=true\&sslfactory=org.postgresql.ssl.NonValidatingFactory"
+else
+    echo "DEEPDIVE_JDBC_URL=jdbc:postgresql://$host${port:+:$port}/$dbname" 
+fi
 echo "export DEEPDIVE_JDBC_DRIVER DEEPDIVE_JDBC_URL"
 
 # XXX several environment variables for legacy apps
@@ -29,4 +33,9 @@ echo "PGHOST=${host}"
 echo "PGPORT=${port}"
 echo "PGUSER=${user}"
 echo "PGPASSWORD=\$DBPASSWORD"
-echo "export PGHOST PGPORT PGUSER PGPASSWORD"
+if [ ${ssl} = "true"  ]; then
+    echo "PGSSLMODE=require"
+else
+    echo "PGSSLMODE=disable"
+fi
+echo "export PGHOST PGPORT PGUSER PGPASSWORD PGSSLMODE"

--- a/shell/parse-url.sh
+++ b/shell/parse-url.sh
@@ -18,4 +18,7 @@ port=${port#:}
 user=${user_password%:*}
 password=${user_password#$user}
 password=${password#:}
-dbname=${rest}  # TODO do we need to strip any parameters from the rest of the URL?
+dbname=${rest%\?*}
+rest1=${rest#$dbname?}
+ssl=${rest1#ssl=} # TODO we only support ssl parameter from the rest of the URL
+#dbname=${rest}  # TODO do we need to strip any parameters from the rest of the URL?


### PR DESCRIPTION
Added SSL support.
In order to support ssl connections. You can specify this in the connection string with:

    jdbc:postgresql://localhost:5432/dbname?ssl=true
Then Deepdvie will run SSL connection with the non-validating ssl factory:

    jdbc:postgresql://localhost:5432/dbname?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory
