### PR TITLE
Fixes grounding failure due to long pathnames

### DIFF
--- a/src/main/scala/org/deepdive/inference/InferenceNamespace.scala
+++ b/src/main/scala/org/deepdive/inference/InferenceNamespace.scala
@@ -65,18 +65,4 @@ object InferenceNamespace {
     }
   }
 
-  // converting format scripts
-  val utilFolder = "util"
-  val formatConvertingScriptName = "tobinary.py"
-  val formatConvertingWorkerName = "format_converter"
-
-  def getFormatConvertingScriptPath : String = {
-    new File(s"${Context.deepdiveHome}/${utilFolder}/${formatConvertingScriptName}").getCanonicalPath()
-  }
-  def getFormatConvertingWorkerPath : String = {
-    new File(s"${Context.deepdiveHome}/${utilFolder}/${formatConvertingWorkerName}").getCanonicalPath()
-  }
-
-  def getActiveScript : String = new File(s"${Context.deepdiveHome}/${utilFolder}/active.sh").getCanonicalPath()
-
 }

--- a/src/main/scala/org/deepdive/inference/SQLInferenceRunner.scala
+++ b/src/main/scala/org/deepdive/inference/SQLInferenceRunner.scala
@@ -402,8 +402,7 @@ trait SQLInferenceRunner extends InferenceRunner with Logging {
   def convertGroundingFormat(groundingPath: String) {
     log.info("Converting grounding file format...")
     // TODO: this python script is dangerous and ugly. It changes too many states!
-    val cmd = s"python ${InferenceNamespace.getFormatConvertingScriptPath} ${groundingPath} " +
-        s"${InferenceNamespace.getFormatConvertingWorkerPath} ${Context.outputDir}"
+    val cmd = Seq("sh", "-c", s"cd ${groundingPath} && tobinary.py . format_converter ${Context.outputDir}")
     log.debug("Executing: " + cmd)
     val exitValue = cmd!(ProcessLogger(
       out => log.info(out),
@@ -417,7 +416,7 @@ trait SQLInferenceRunner extends InferenceRunner with Logging {
   }
 
   def generateAcitve(groundingPath: String) {
-    val cmd = s"${InferenceNamespace.getActiveScript}"
+    val cmd = s"active.sh"
     log.debug("Executing: " + cmd)
     val exitValue = cmd!(ProcessLogger(
       out => log.info(out),

--- a/src/test/scala/unit/inference/SQLInferenceDataStoreSpec.scala
+++ b/src/test/scala/unit/inference/SQLInferenceDataStoreSpec.scala
@@ -506,15 +506,14 @@ trait SQLInferenceRunnerSpec extends FunSpec with BeforeAndAfter { this: SQLInfe
       it("format converter should work (flat/array type)") {
         cancelUnlessPostgres()
         val resourceFolder = new File(getClass.getResource("/format_converter").toURI).getAbsolutePath
-        val converter = InferenceNamespace.getFormatConvertingWorkerPath
         val variableFile = s"${resourceFolder}/dd_variables"
         val factorFile = s"${resourceFolder}/dd_factors"
         val weightFile = s"${resourceFolder}/dd_weights"
         val edgeFile = s"${resourceFolder}/dd_edges"
 
-        s"${converter} variable ${variableFile}".!
-        s"${converter} factor ${factorFile} 2 1 1".!
-        s"${converter} weight ${weightFile}".!
+        s"format_converter variable ${variableFile}".!
+        s"format_converter factor ${factorFile} 2 1 1".!
+        s"format_converter weight ${weightFile}".!
 
         var cmp = s"cmp ${variableFile}.bin ${variableFile}_expected.bin"
         assert(cmp.! == 0)


### PR DESCRIPTION
by changing how tobinary.py is invoked.