### PR TITLE
Compresses factor graph binary files with bzip2

### DIFF
--- a/compiler/compile-config/compile-config-2.01-grounding
+++ b/compiler/compile-config/compile-config-2.01-grounding
@@ -175,7 +175,7 @@ include "sql";
         varPath=\"$DEEPDIVE_GROUNDING_DIR\"/variable/\(.variableName | @sh)
         mkdir -p \"$varPath\"
         cd \"$varPath\"
-        find . -name 'variables-*.bin' -exec rm -rf {} +
+        find . -name 'variables.part-*.bin.bz2' -exec rm -rf {} +
         export DEEPDIVE_LOAD_FORMAT=tsv
 
         # dump the variables, joining the holdout query to determine the type of each variable
@@ -248,7 +248,7 @@ include "sql";
                 ]
             } | asSql | @sh) \\
             command=\("
-                format_converter variable /dev/stdin >(bzip2 >variables.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2)
+                format_converter variable /dev/stdin >(pbzip2 >variables.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2)
             " | @sh) \\
             output_relation=
         "
@@ -473,10 +473,10 @@ include "sql";
             facPath=\"$DEEPDIVE_GROUNDING_DIR\"/factor/\(.factorName | @sh)
             mkdir -p \"$facPath\"
             cd \"$facPath\"
-            find . \\( -name  'factors.part-*.bin' \\
-                    -o -name 'nfactors.part-*.bin' \\
-                    -o -name  'weights.part-*.bin' \\
-                    -o -name 'nweights.part-*.bin' \\
+            find . \\( -name  'factors.part-*.bin.bz2' \\
+                    -o -name 'nfactors.part-*'         \\
+                    -o -name  'weights.part-*.bin.bz2' \\
+                    -o -name 'nweights.part-*'         \\
                     \\) -exec rm -rf {} +
             export DEEPDIVE_LOAD_FORMAT=tsv
 
@@ -505,7 +505,7 @@ include "sql";
                 command=\("
                     # also record the factor count
                     tee >(wc -l >nfactors.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}) |
-                    format_converter factor /dev/stdin >(bzip2 >factors.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2) \(.function_.id
+                    format_converter factor /dev/stdin >(pbzip2 >factors.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2) \(.function_.id
                         ) \(.function_.variables | length
                         ) original \(.function_.variables | map(if .isNegated then "0" else "1" end) | join(" ")
                         ) |
@@ -526,7 +526,7 @@ include "sql";
                     , FROM: [ { table: .weightsTableForDumping } ]
                     } | asSql | @sh) \\
                 command=\("
-                    format_converter weight /dev/stdin >(bzip2 >weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2)
+                    format_converter weight /dev/stdin >(pbzip2 >weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2)
                 " | @sh) \\
                 output_relation=
         "

--- a/compiler/compile-config/compile-config-2.01-grounding
+++ b/compiler/compile-config/compile-config-2.01-grounding
@@ -248,7 +248,7 @@ include "sql";
                 ]
             } | asSql | @sh) \\
             command=\("
-                format_converter variable /dev/stdin variables.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin
+                format_converter variable /dev/stdin >(bzip2 >variables.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2)
             " | @sh) \\
             output_relation=
         "
@@ -505,7 +505,7 @@ include "sql";
                 command=\("
                     # also record the factor count
                     tee >(wc -l >nfactors.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}) |
-                    format_converter factor /dev/stdin factors.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin \(.function_.id
+                    format_converter factor /dev/stdin >(bzip2 >factors.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2) \(.function_.id
                         ) \(.function_.variables | length
                         ) original \(.function_.variables | map(if .isNegated then "0" else "1" end) | join(" ")
                         ) |
@@ -526,7 +526,7 @@ include "sql";
                     , FROM: [ { table: .weightsTableForDumping } ]
                     } | asSql | @sh) \\
                 command=\("
-                    format_converter weight /dev/stdin weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin
+                    format_converter weight /dev/stdin >(bzip2 >weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2)
                 " | @sh) \\
                 output_relation=
         "
@@ -565,15 +565,15 @@ include "sql";
         for v in \($variableNames); do
             mkdir -p variables/\"$v\"
             find \"$DEEPDIVE_GROUNDING_DIR\"/variable/\"$v\" \\
-                -name 'variables.part-*.bin' -exec ln -sfnv -t variables/\"$v\"/ {} + \\
+                -name 'variables.part-*.bin.bz2' -exec ln -sfnv -t variables/\"$v\"/ {} + \\
                 #
         done
         for f in \($factorNames); do
             mkdir -p {factors,weights}/\"$f\"
             find \"$DEEPDIVE_GROUNDING_DIR\"/factor/\"$f\" \\
-                -name 'factors.part-*.bin' -exec ln -sfnv -t factors/\"$f\"/ {} + \\
+                -name 'factors.part-*.bin.bz2' -exec ln -sfnv -t factors/\"$f\"/ {} + \\
                 -o \\
-                -name 'weights.part-*.bin' -exec ln -sfnv -t weights/\"$f\"/ {} + \\
+                -name 'weights.part-*.bin.bz2' -exec ln -sfnv -t weights/\"$f\"/ {} + \\
                 #
         done
 

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -13,7 +13,7 @@
             mkdir -p weights
             [ -d factorgraph ] || error \"No factorgraph found\"
             # run inference engine for learning and inference
-            flatten() { find -L \"$@\" -type f -exec cat {} +; }
+            flatten() { find -L \"$@\" -type f -exec bzcat {} +; }
             \($deepdive.sampler.sampler_cmd // "sampler-dw") \\
                 gibbs \\
                 -w <(flatten factorgraph/weights) \\
@@ -38,7 +38,7 @@
                 # no need to run inference unless the weights are fresher
                 # XXX this skipping may cause confusion
                 # run sampler for performing inference with given weights without learning
-                flatten() { find -L \"$@\" -type f -exec cat {} +; }
+                flatten() { find -L \"$@\" -type f -exec bzcat {} +; }
                 \($deepdive.sampler.sampler_cmd // "sampler-dw") \\
                     gibbs \\
                     -l 0 \\

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -13,7 +13,7 @@
             mkdir -p weights
             [ -d factorgraph ] || error \"No factorgraph found\"
             # run inference engine for learning and inference
-            flatten() { find -L \"$@\" -type f -exec bzcat {} +; }
+            flatten() { find -L \"$@\" -type f -exec pbzip2 -c -d -k {} +; }
             \($deepdive.sampler.sampler_cmd // "sampler-dw") \\
                 gibbs \\
                 -w <(flatten factorgraph/weights) \\
@@ -38,7 +38,7 @@
                 # no need to run inference unless the weights are fresher
                 # XXX this skipping may cause confusion
                 # run sampler for performing inference with given weights without learning
-                flatten() { find -L \"$@\" -type f -exec bzcat {} +; }
+                flatten() { find -L \"$@\" -type f -exec pbzip2 -c -d -k {} +; }
                 \($deepdive.sampler.sampler_cmd // "sampler-dw") \\
                     gibbs \\
                     -l 0 \\

--- a/extern/bundle.conf
+++ b/extern/bundle.conf
@@ -7,3 +7,4 @@ pv
 moreutils
 graphviz
 bc
+pbzip2

--- a/extern/bundled/pbzip2
+++ b/extern/bundled/pbzip2
@@ -1,0 +1,1 @@
+../buildkit/depends/common/pbzip2


### PR DESCRIPTION
when grounding, and decompresses on the fly with bzcat when running the
sampler.

This cuts a 2MB (2300279 bytes) factor graph down to 184kB (184224 bytes)
(one produced by the test with spouse_example/ddlog app) with negligible
impact on runtime (or even faster!).

```bash
groundingTime() {
    local log=$1
    tstart=$((sed -n '\@process/grounding/.*/dump@{ p; q; }' | awk '{print $2}') <$log)
    tend=$((sed -n '\@LEARNING EPOCH 0@{ p; q; }' | awk '{print $2}') <$log)
    echo $(date --date="$tend" +%s.%N) - $(date --date="$tstart" +%s.%N) | bc
}

$ # dump from database and load by sampler without compression
$ groundingTime test/postgresql/spouse_example/ddlog/run/20151221/040549.120506000/log.txt
3.363981000

$ # dump from database and load by sampler with compression
$ groundingTime test/postgresql/spouse_example/ddlog/run/20151221/034709.985065000/log.txt
3.319830000
```

Note that gzip has a 4GB limitation, so bzip2 was used despite its
higher computational cost.  xz may be another good candidate to consider.