### PR TITLE
Fixed weight table for Postgres-XL

### DIFF
--- a/src/main/scala/org/deepdive/inference/SQLInferenceRunner.scala
+++ b/src/main/scala/org/deepdive/inference/SQLInferenceRunner.scala
@@ -913,13 +913,13 @@ trait SQLInferenceRunner extends InferenceRunner with Logging {
       DROP TABLE IF EXISTS __dd_tmp_${WeightsTable};
       CREATE TABLE __dd_tmp_${WeightsTable} AS
       SELECT w.id, fw.weight
-      FROM ${WeightsTable} w, 
+      FROM ${WeightsTable} w,
            ${fromWeightTable} fw
       WHERE w.description = fw.description;
       """)
 
     execute(s"""
-      UPDATE ${WeightsTable} SET initvalue = weight 
+      UPDATE ${WeightsTable} SET initvalue = weight
       FROM __dd_tmp_${WeightsTable} fw
       WHERE ${WeightsTable}.id = fw.id;
       DROP TABLE IF EXISTS __dd_tmp_${WeightsTable};

--- a/src/main/scala/org/deepdive/inference/SQLInferenceRunner.scala
+++ b/src/main/scala/org/deepdive/inference/SQLInferenceRunner.scala
@@ -910,9 +910,19 @@ trait SQLInferenceRunner extends InferenceRunner with Logging {
 
     // Already set -l 0 for sampler
     execute(s"""
-      UPDATE ${WeightsTable} SET initvalue = weight
-      FROM ${fromWeightTable}
-      WHERE ${WeightsTable}.description = ${fromWeightTable}.description;
+      DROP TABLE IF EXISTS __dd_tmp_${WeightsTable};
+      CREATE TABLE __dd_tmp_${WeightsTable} AS
+      SELECT w.id, fw.weight
+      FROM ${WeightsTable} w, 
+           ${fromWeightTable} fw
+      WHERE w.description = fw.description;
+      """)
+
+    execute(s"""
+      UPDATE ${WeightsTable} SET initvalue = weight 
+      FROM __dd_tmp_${WeightsTable} fw
+      WHERE ${WeightsTable}.id = fw.id;
+      DROP TABLE IF EXISTS __dd_tmp_${WeightsTable};
       """)
   }
 


### PR DESCRIPTION
PGXL doesn't support correlated UPDATE involving multiple nodes:
http://sourceforge.net/p/postgres-xc/mailman/message/26727433/

This workaround prevents the issue by materializing the table first. It should work for both PGXL and other databases.
See #446 for more discussions.