### PR TITLE
fix db-create for greenplum

### DIFF
--- a/database/db-driver/greenplum/db-create
+++ b/database/db-driver/greenplum/db-create
@@ -1,1 +1,1 @@
-../postgresql/db-create
+../mysql/db-create

--- a/database/db-driver/mysql/db-create
+++ b/database/db-driver/mysql/db-create
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# db-create -- Creates a table or view with given definition for MySQL
+# db-create -- Creates a table or view with given definition for MySQL/Greenplum
 # See: postgresql/db-create
 ##
 set -euo pipefail


### PR DESCRIPTION
While creating a table during a deepdive run, the driver db-create currently create a syntax containing "include all", which is not supported by Greenplum. 

This PR simply modifies the alias of greenplum/db-create from postgresql/db-create to mysql/db-create