### PR TITLE
Fixes deepdive-do to terminate processes more cleanly

### DIFF
--- a/runner/deepdive-do
+++ b/runner/deepdive-do
@@ -33,7 +33,7 @@ signals="HUP INT QUIT TERM"
 signal_pg() {
     local sig=$1
     # send given signal to the process group
-    ps_descendants $$ | xargs kill -$sig || true
+    exec ps_descendants $$ | xargs kill -$sig || true
 }
 keep_signal_pg() {
     local sig=$1
@@ -46,7 +46,7 @@ keep_signal_pg() {
     # until no process remains in the process group
     # keep sending the same signal with increasing interval
     local timeout=1
-    while [[ -n $(ps_descendants $$) ]]; do
+    while [[ -n $(exec ps_descendants $$) ]]; do
         echo "Processes still alive, sending SIG$sig again to descendants of PID $$ in $timeout secs"
         sleep $timeout && signal_pg $sig && let timeout*=2 || {
             # or send KILL if something goes wrong

--- a/runner/deepdive-do
+++ b/runner/deepdive-do
@@ -30,36 +30,10 @@ mkdir -p run/"$runDir"
 
 # forward signals to descendants to make sure no dangling processes remain
 signals="HUP INT QUIT TERM"
-list_descendant_pids() {
-    local pid=$$
-    local ppid=$BASHPID
-    # find the descendent processes
-    ps ax -o pid=,ppid= |
-    sed '
-        # trim whitespaces
-        s/[[:space:]][[:space:]]*/ /; s/^ //; s/ $//
-        # exclude bash itself as well as these sed, tsort, and ps processes here
-        /[[:space:]]'"$ppid"'$/d
-        # emit the original pid-ppid edge
-        p
-        # inject an edge from bash to everyone else to create a cycle
-        s/^/'"$pid"' /; s/[[:space:]][^[:space:]]*$//
-    '  |
-    # use tsort to find the injected cycle from the mutated process tree
-    tsort 2>&1 |
-    sed '
-        /^tsort: /!d
-        /input contains a loop:$/d
-        s/^tsort: //
-    ' |
-    sort -u |
-    # exclude bash and subshell
-    grep -vxF "$pid"$'\n'"$ppid"
-}
 signal_pg() {
     local sig=$1
     # send given signal to the process group
-    list_descendant_pids | xargs kill -$sig 2>/dev/null || true
+    ps_descendants $$ | xargs kill -$sig || true
 }
 keep_signal_pg() {
     local sig=$1
@@ -72,7 +46,7 @@ keep_signal_pg() {
     # until no process remains in the process group
     # keep sending the same signal with increasing interval
     local timeout=1
-    while [[ -n $(list_descendant_pids) ]]; do
+    while [[ -n $(ps_descendants $$) ]]; do
         echo "Processes still alive, sending SIG$sig again to descendants of PID $$ in $timeout secs"
         sleep $timeout && signal_pg $sig && let timeout*=2 || {
             # or send KILL if something goes wrong

--- a/runner/deepdive-do
+++ b/runner/deepdive-do
@@ -33,7 +33,7 @@ signals="HUP INT QUIT TERM"
 signal_pg() {
     local sig=$1
     # send given signal to the process group
-    exec ps_descendants $$ | xargs kill -$sig || true
+    exec ps_descendants $$ | xargs -t kill -$sig || true
 }
 keep_signal_pg() {
     local sig=$1
@@ -87,6 +87,8 @@ fi
 cleanup() {
     cd "$DEEPDIVE_APP"
     [[ ! run/RUNNING -ef run/"$runDir" ]] || rm -f run/RUNNING
+    # make sure no descendant processes are left behind
+    [[ -z $(exec ps_descendants $$) ]] || keep_signal_pg TERM
 }
 trap cleanup EXIT
 #  and leaving an ABORTED symlink upon error

--- a/runner/ps_descendants
+++ b/runner/ps_descendants
@@ -1,91 +1,68 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python
 # ps_descendants -- Lists all descendant PIDs of given PID as well as those sharing the PGID
 # $ ps_descendants PID
 ##
-set -eu
 
-[[ $# -gt 0 ]] || usage "$0" "Missing PID"
+import sys,os,subprocess,re
 
-# how to access PID-PPID-PGID snapshot
-ps_snapshot=$(
-    exec ps ax -o pid=,ppid=,pgid= |
-    exec sed '
-        s/[[:space:]][[:space:]]*/ /; s/^ //; s/ $//  # tidy whitespaces
-    '
-)
-pid_ppid() {
-    sed <<<"$ps_snapshot" '
-        s/[[:space:]][^[:space:]]*$//  # project to PID-PPID
-    '
-}
-pid_pgid() {
-    sed <<<"$ps_snapshot" '
-        s/[[:space:]][^[:space:]]*[[:space:]]/ /  # project to PID-PGID
-    '
-}
-# how to find cycles in a graph
-pids_in_cycle() {
-    # use tsort to find the injected cycle from the mutated process tree
-    tsort 2>&1 |
-    sed '
-        /^tsort: /!d
-        /input contains a loop:$/d
-        s/^tsort: //
-    ' |
-    sort -u
-}
-# how to find the ancestor processes, i.e., parent, parent of parent, and so on
-ancestors() {
-    local pid=$1
-    {
-        # form a cycle by creating an edge from root to given PID
-        echo 1 $pid
-        pid_ppid
-    } |
-    pids_in_cycle
-}
-# how to find the descendant processes, i.e., children, children of children
-descendants() {
-    local pid=$1
-    pid_ppid |
-    sed '
-        p                                              # emit the original PID-PPID edge
-        s/^/'"$pid"' /; s/[[:space:]][^[:space:]]*$//  # inject an edge from bash to everyone else to create a cycle
-    ' |
-    pids_in_cycle
-}
-# how to find the processes sharing the PGID
-same_process_group() {
-    local pid=$1
-    local pgid=$(sed <<<"$ps_snapshot" '
-        /^'"$pid"'[[:space:]]/!d
-        s/.*[[:space:]]//
-    ')
-    # assume it was a process group leader, i.e., the PGID was the same as PID if not found
-    pgid=${pgid:-$pid}
-    pid_pgid |
-    sed '
-        /[[:space:]]'"$pgid"'$/!d  # select lines with the PGID
-        s/[[:space:]].*$//         # project to PID
-    '
-}
+if len(sys.argv) != 2:
+    os.execvp("usage", ["usage", sys.argv[0], "Missing PID"])
 
-pid=$1; shift
-this=$BASHPID
-{
-    # list descendants reachable via PID-PPID
-    descendants "$pid"
-    # as well as those in the same process group
-    same_process_group "$pid" | grep -vxf <(
-        # except descendants of the highest ancestor other than PID 1
-        grandestparent=$(ancestors "$pid" | grep -vxF 1 | head -1)
-        descendants "$grandestparent"
-    )
-} | sort -u |
-grep -vxf <(
-    # exclude the process itself
-    echo $pid
-    # and this one's descendants
-    descendants $this
-    #echo "$ps_snapshot" >&2
-) || true
+PID = sys.argv[1]
+
+# list of children PIDs
+ps_children = {}
+ppid_by_pid = {}
+# PIDs by PGID
+ps_by_pgid = {}
+pgid_by_pid = {}
+
+# take a snapshot of PIDs, PPIDs, PGIDs using ps command, and index them in a handy way
+ps_snapshot = subprocess.check_output(["ps", "ax", "-o", "ppid=,pid=,pgid="])
+pid_self = str(os.getpid())
+for line in ps_snapshot.split("\n"):
+    line = line.strip()
+    if len(line) == 0: break
+    ppid,pid,pgid = re.compile(r" +").split(line)
+    # avoid indexing this process' children as well as itself
+    if ppid == pid_self or pid == pid_self: continue
+    # index PPID edge
+    if ppid not in ps_children: ps_children[ppid] = set()
+    ps_children[ppid].add(pid)
+    ppid_by_pid[pid] = ppid
+    # group by PGID
+    if pgid not in ps_by_pgid: ps_by_pgid[pgid] = set()
+    ps_by_pgid[pgid].add(pid)
+    pgid_by_pid[pid] = pgid
+
+def descendants(pid):
+    ds = set([pid])
+    if pid in ps_children:
+        for c in ps_children[pid]:
+            ds |= descendants(c)
+    return ds
+
+def ancestors(pid):
+    ppids = []
+    while pid in ppid_by_pid:
+        ppid = ppid_by_pid[pid]
+        ppids.insert(0, ppid)
+        pid = ppid
+    return ppids
+
+# list descendants reachable via PID-PPID
+pids = descendants(PID)
+# as well as those in the same process group except descendants of the highest ancestor other than PID 1
+PGID = pgid_by_pid[PID] if PID in pgid_by_pid else PID
+if PGID in ps_by_pgid:
+    ppids = [p for p in ancestors(PID) if p not in ["0", "1"]]
+    pids |= ps_by_pgid[PGID] - (
+            descendants(ppids[0]) if len(ppids) > 0 else set()
+            )
+
+# excluding the given PID as well as this Python process itself
+pids -= set([PID])
+
+# output PIDs
+if len(pids) > 0:
+    print "\n".join(pids)

--- a/runner/ps_descendants
+++ b/runner/ps_descendants
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# ps_descendants -- Lists all descendant PIDs of given PID as well as those sharing the PGID
+# $ ps_descendants PID
+##
+set -eu
+
+[[ $# -gt 0 ]] || usage "$0" "Missing PID"
+
+# how to access PID-PPID-PGID snapshot
+ps_snapshot=$(
+    exec ps ax -o pid=,ppid=,pgid= |
+    exec sed '
+        s/[[:space:]][[:space:]]*/ /; s/^ //; s/ $//  # tidy whitespaces
+    '
+)
+pid_ppid() {
+    sed <<<"$ps_snapshot" '
+        s/[[:space:]][^[:space:]]*$//  # project to PID-PPID
+    '
+}
+pid_pgid() {
+    sed <<<"$ps_snapshot" '
+        s/[[:space:]][^[:space:]]*[[:space:]]/ /  # project to PID-PGID
+    '
+}
+# how to find cycles in a graph
+pids_in_cycle() {
+    # use tsort to find the injected cycle from the mutated process tree
+    tsort 2>&1 |
+    sed '
+        /^tsort: /!d
+        /input contains a loop:$/d
+        s/^tsort: //
+    ' |
+    sort -u
+}
+# how to find the ancestor processes, i.e., parent, parent of parent, and so on
+ancestors() {
+    local pid=$1
+    {
+        # form a cycle by creating an edge from root to given PID
+        echo 1 $pid
+        pid_ppid
+    } |
+    pids_in_cycle
+}
+# how to find the descendant processes, i.e., children, children of children
+descendants() {
+    local pid=$1
+    pid_ppid |
+    sed '
+        p                                              # emit the original PID-PPID edge
+        s/^/'"$pid"' /; s/[[:space:]][^[:space:]]*$//  # inject an edge from bash to everyone else to create a cycle
+    ' |
+    pids_in_cycle
+}
+# how to find the processes sharing the PGID
+same_process_group() {
+    local pid=$1
+    local pgid=$(sed <<<"$ps_snapshot" '
+        /^'"$pid"'[[:space:]]/!d
+        s/.*[[:space:]]//
+    ')
+    # assume it was a process group leader, i.e., the PGID was the same as PID if not found
+    pgid=${pgid:-$pid}
+    pid_pgid |
+    sed '
+        /[[:space:]]'"$pgid"'$/!d  # select lines with the PGID
+        s/[[:space:]].*$//         # project to PID
+    '
+}
+
+pid=$1; shift
+this=$BASHPID
+{
+    # list descendants reachable via PID-PPID
+    descendants "$pid"
+    # as well as those in the same process group
+    same_process_group "$pid" | grep -vxf <(
+        # except descendants of the highest ancestor other than PID 1
+        grandestparent=$(ancestors "$pid" | grep -vxF 1 | head -1)
+        descendants "$grandestparent"
+    )
+} | sort -u |
+grep -vxf <(
+    # exclude the process itself
+    echo $pid
+    # and this one's descendants
+    descendants $this
+    #echo "$ps_snapshot" >&2
+) || true

--- a/runner/test/env.sh
+++ b/runner/test/env.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Unit tests for DeepDive runner
+# Usage: . "$BATS_TEST_DIRNAME"/env.sh >&2  # from .bats files typically on the same directory
+
+. "${BASH_SOURCE%/*}"/../../test/env.sh

--- a/runner/test/ps_descendants.bats
+++ b/runner/test/ps_descendants.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+. "$BATS_TEST_DIRNAME"/env.sh
+
+setup() {
+    pidsfile=$(mktemp "$BATS_TMPDIR"/ps_descendants-pids.XXXXXXX)
+}
+teardown() {
+    rm -f $pidsfile
+}
+
+@test "ps_descendants usage" {
+    # should accept exactly one PID
+    ps_descendants 1
+    ! ps_descendants
+    ! ps_descendants 123 456
+}
+
+@test "ps_descendants basic" {
+    export pidsfile
+    : >$pidsfile
+    sh -c '
+        sleep 0.2 &
+        echo $! >>$pidsfile
+        wait
+    ' &
+    pid=$!
+
+    sleep 0.1
+    diff -u $pidsfile <(ps_descendants $pid)
+}

--- a/stage.sh
+++ b/stage.sh
@@ -75,6 +75,7 @@ stage runner/format_timestamp                                     util/
 stage runner/mark_done                                            util/
 stage runner/resolve-args-to-do.sh                                util/
 stage runner/show_progress                                        util/
+stage runner/ps_descendants                                       util/
 
 stage runner/deepdive-compute                                     util/
 stage runner/load-compute-driver.sh                               util/


### PR DESCRIPTION
The previous way of terminating processes from deepdive-do upon interrupt or signal is incomplete.  Before deepdive-do enumerates processes, Ctrl-C could also kill some intermediate process, orphan or detach their children from the original process tree, hence make it impossible for the previous approach to terminate all of them cleanly.  For example, when dumping processes in grounding were interrupted with Ctrl-C on Linux, a lot (a few hundreds!) of orphan processes stayed alive although their parent bash processes were terminated.  To remedy this, now the descendants include all processes that share the PGID with the deepdive-do that has no common ancestor other than PID 1, i.e., being in an orphaned process subtree.

Switches to Python implementation from bash as things became a lot more complicated.

Tests should ideally cover this complex case, but it's a little tricky to fake such process configuration artificially.