### PR TITLE
Handy way to use DDlog instead of SQL to query the database

### DIFF
--- a/database/deepdive-query
+++ b/database/deepdive-query
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# deepdive-query -- Runs a DDlog query against the database for the DeepDive application
+# > deepdive query DDLOG_QUERY
+#
+# You must either have the DEEPDIVE_DB_URL environment set to a proper URL or
+# run this command under a DeepDive application where the URL is set in a db.url file.
+#
+# > deepdive query DDLOG_QUERY format=FORMAT [header=1]
+# Evaluates a given DDlog query and prints the result in the specified FORMAT.
+# FORMAT can be tsv, csv, or json, and defaults to tsv format.
+# Prints the header line for tsv and csv format when header=1 is given.
+##
+set -euo pipefail
+
+[[ $# -gt 0 ]] || usage "$0" "Missing DDLOG_QUERY"
+DDlogQuery=$1; shift
+
+DEEPDIVE_APP=$(find-deepdive-app)
+export DEEPDIVE_APP
+cd "$DEEPDIVE_APP"
+
+sql=$(ddlog query "$DDlogQuery" app.ddlog)
+echo >&2 "Running SQL: $sql"
+if [[ $# -gt 0 ]]; then
+    exec deepdive-sql eval "$sql" "$@"
+else
+    exec deepdive-sql "$sql"
+fi

--- a/database/deepdive-query
+++ b/database/deepdive-query
@@ -5,12 +5,25 @@
 # You must either have the DEEPDIVE_DB_URL environment set to a proper URL or
 # run this command under a DeepDive application where the URL is set in a db.url file.
 #
+# > deepdive query -n DDLOG_QUERY
+# Just shows the SQL query instead of actually running it through the `deepdive sql` command.
+#
 # > deepdive query DDLOG_QUERY format=FORMAT [header=1]
 # Evaluates a given DDlog query and prints the result in the specified FORMAT.
 # FORMAT can be tsv, csv, or json, and defaults to tsv format.
 # Prints the header line for tsv and csv format when header=1 is given.
 ##
 set -euo pipefail
+
+JustShowSQL=false
+while getopts "n" o; do
+    case $o in
+        n)
+            JustShowSQL=true
+            ;;
+    esac
+done
+shift $(($OPTIND - 1))
 
 [[ $# -gt 0 ]] || usage "$0" "Missing DDLOG_QUERY"
 DDlogQuery=$1; shift
@@ -20,8 +33,9 @@ export DEEPDIVE_APP
 cd "$DEEPDIVE_APP"
 
 sql=$(ddlog query "$DDlogQuery" app.ddlog)
-echo >&2 "Running SQL: $sql"
-if [[ $# -gt 0 ]]; then
+if $JustShowSQL; then
+    echo "$sql"
+elif [[ $# -gt 0 ]]; then
     exec deepdive-sql eval "$sql" "$@"
 else
     exec deepdive-sql "$sql"

--- a/stage.sh
+++ b/stage.sh
@@ -87,6 +87,7 @@ stage runner/computers-default.conf                               util/
 stage .build/submodule/runner/mkmimo/mkmimo                       util/
 
 # DeepDive database operations and drivers
+stage database/deepdive-query                                     util/
 stage database/deepdive-db                                        util/
 stage database/deepdive-initdb                                    util/
 stage database/deepdive-sql                                       util/


### PR DESCRIPTION
This is probably a key step for making our docs appear simple and easy.  Examples will explain what this piece is about:
```bash
# easy browsing
deepdive query '?- has_spouse_candidates(_,_,_,desc,id,_).'

# quick counting
deepdive query 'COUNT(id) ?- has_spouse_candidates(_,_,_,desc,id,_).'

# easy joins
deepdive query '
doc ?-
    has_spouse_candidates(_,_,sentence,_,candidate,_),
    sentences(doc, _,_,_,_,_,_,_, sentence).
'

# easy group by
deepdive query '
doc, COUNT(candidate) ?-
    has_spouse_candidates(_,_,sentence,_,candidate,_),
    sentences(doc, _,_,_,_,_,_,_, sentence).
'

# histograms using more than one rule (to group/count twice) and even ordering the result!
deepdive query '
num_candidates_by_doc(doc, COUNT(candidate)) :-
    has_spouse_candidates(_,_,sentence,_,candidate,_),
    sentences(doc, _,_,_,_,_,_,_, sentence).

@order_by num_candidates, COUNT(doc) ?- num_candidates_by_doc(doc, num_candidates).
'

# limiting output (top 10)
deepdive query '
doc, @order_by("DESC") COUNT(candidate) | 10 ?-
    has_spouse_candidates(_,_,sentence,_,candidate,_),
    sentences(doc, _,_,_,_,_,_,_, sentence).
'

# dumping to tsv/csv/etc. format files
deepdive query '?- has_spouse_candidates(_,_,_,desc,id,_).'  format=csv >candidates_desc_id.csv
```

`deepdive query -n DDLOG` shows the SQL to be executed.