### PR TITLE
Fixes `deepdive compute` to `deepdive compute execute`

### DIFF
--- a/compiler/compile-code/compile-code-tsv_extractor
+++ b/compiler/compile-code/compile-code-tsv_extractor
@@ -20,7 +20,7 @@ cd \"$(dirname \"$0\")\"
 export DEEPDIVE_CURRENT_PROCESS_NAME=\(.name | @sh)
 export DEEPDIVE_LOAD_FORMAT=tsv
 
-deepdive compute \\
+deepdive compute execute \\
     input_sql=\(.input | @sh) \\
     command=\(.udf | @sh) \\
     output_relation=\(.output_relation | @sh) \\

--- a/compiler/compile-config/compile-config-2.01-grounding
+++ b/compiler/compile-config/compile-config-2.01-grounding
@@ -163,7 +163,7 @@ def factorWeightDescriptionSqlExpr:
         export DEEPDIVE_UNLOAD_MATERIALIZED=false
 
         # dump the variables, joining the holdout query to determine the type of each variable
-        deepdive compute \\
+        deepdive compute execute \\
             input_sql=\(
             { SELECT:
                 [ { column: "id" }
@@ -458,7 +458,7 @@ def factorWeightDescriptionSqlExpr:
             export DEEPDIVE_UNLOAD_MATERIALIZED=false
 
             # dump the factors joining the assigned weight ids, converting into binary format for the inference engine
-            deepdive compute \\
+            deepdive compute execute \\
                 input_sql=\(
                     { SELECT:
                         [ { table: "weights", column: "id", alias: "weight_id" }
@@ -515,7 +515,7 @@ def factorWeightDescriptionSqlExpr:
             reuseFlag=\"$DEEPDIVE_GROUNDING_DIR\"/factor/weights.reuse
 
             # dump the weights (except the description column), converting into binary format for the inference engine
-            deepdive compute \\
+            deepdive compute execute \\
                 input_sql=\"$(if [[ -e \"$reuseFlag\" ]]; then
                     echo \(
                     # dump weights with initvalue from previously learned ones

--- a/runner/deepdive-compute
+++ b/runner/deepdive-compute
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 # deepdive-compute -- Runs a UDF using a computer against the database
+# > deepdive compute COMMAND [NAME=VALUE]...
+#
 # > export DEEPDIVE_COMPUTER=...
-# > deepdive compute input_sql=... command=... output_relation=...
+# > deepdive compute execute input_sql=... command=... output_relation=...
 ##
 set -eu
+
+[[ $# -gt 0 ]] || usage "$0" "Missing COMMAND"
+Command=$1
 
 # parse settings
 . load-db-driver.sh
 . load-compute-driver.sh
 
-exec compute-execute "$@"
+if type compute-"$Command" &>/dev/null; then
+    exec compute-"$Command" "$@"
+else
+    error "$Command: No such command for deepdive compute"
+fi


### PR DESCRIPTION
to leave room for the sub-command for future extensions by compute drivers