### PR TITLE
`deepdive-model` for reusing weights and expediting other model tasks

### DIFF
--- a/compiler/compile-config/compile-config-2.01-grounding
+++ b/compiler/compile-config/compile-config-2.01-grounding
@@ -436,7 +436,7 @@ then . else
 
 
 ## factor/*/dump
-# The factors and weights are dumped into a set of binary files for the inference engine.
+# The factors are dumped into a set of binary files for the inference engine.
 | .deepdive_.execution.processes += merge($deepdive.inference.factors_[] | {
     # add a process for grounding factors and weights
     "process/grounding/factor/\(.factorName)/dump": {
@@ -451,13 +451,11 @@ then . else
             find . \\( -name  'factors.part-*.bin.bz2' \\
                     -o -name 'nfactors.part-*'         \\
                     -o -name   'nedges.part-*'         \\
-                    -o -name  'weights.part-*.bin.bz2' \\
-                    \\) -exec rm -rf {} +
+                   \\) -exec rm -rf {} +
             export DEEPDIVE_LOAD_FORMAT=tsv
             export DEEPDIVE_UNLOAD_MATERIALIZED=false
 
             # dump the factors joining the assigned weight ids, converting into binary format for the inference engine
-            DEEPDIVE_CURRENT_PROCESS_NAME=\"${DEEPDIVE_CURRENT_PROCESS_NAME}.factors\" \\
             deepdive compute \\
                 input_sql=\(
                     { SELECT:
@@ -489,9 +487,29 @@ then . else
                     tee nedges.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}
                 " | @sh) \\
                 output_relation=
+        "
+    }
+})
+
+## factor/*/dump_weights
+# The factors and weights are dumped into a set of binary files for the inference engine.
+| .deepdive_.execution.processes += merge($deepdive.inference.factors_[] | {
+    # add a process for grounding factors and weights
+    "process/grounding/factor/\(.factorName)/dump_weights": {
+        dependencies_: [
+            "process/grounding/factor/\(.factorName)/assign_weight_id"
+        ],
+        style: "cmd_extractor", cmd: "
+            : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
+            facPath=\"$DEEPDIVE_GROUNDING_DIR\"/factor/\(.factorName | @sh)
+            mkdir -p \"$facPath\"
+            cd \"$facPath\"
+            find . \\( -name  'weights.part-*.bin.bz2' \\
+                   \\) -exec rm -rf {} +
+            export DEEPDIVE_LOAD_FORMAT=tsv
+            export DEEPDIVE_UNLOAD_MATERIALIZED=false
 
             # dump the weights (except the description column), converting into binary format for the inference engine
-            DEEPDIVE_CURRENT_PROCESS_NAME=\"${DEEPDIVE_CURRENT_PROCESS_NAME}.weights\" \\
             deepdive compute \\
                 input_sql=\(
                     { SELECT:
@@ -521,6 +539,7 @@ then . else
         ), (
             $deepdive.inference.factors_[]
             | "process/grounding/factor/\(.factorName)/dump"
+            , "process/grounding/factor/\(.factorName)/dump_weights"
         ), (
             "process/grounding/global_weight_table"
         )],

--- a/compiler/compile-config/compile-config-2.01-grounding
+++ b/compiler/compile-config/compile-config-2.01-grounding
@@ -11,6 +11,15 @@ if (.deepdive_.schema.variables_  | length) == 0
 or (.deepdive_.inference.factors_ | length) == 0
 then . else
 
+def factorWeightDescriptionSqlExpr:
+    [ ("\(.factorName)-" | asSqlLiteral)
+    , (.weight_.params[] |
+        "CASE WHEN \(asSqlIdent) IS NULL THEN ''
+              ELSE \(asSqlIdent) || ''  -- XXX CAST(... AS TEXT) unsupported by MySQL
+          END"
+      )
+    ] | join(" ||\("-" | asSqlLiteral)|| ");
+
 .deepdive_ as $deepdive
 
 ###############################################################################
@@ -343,14 +352,7 @@ then . else
                     [ { column: "id" }
                     , { column: "isfixed" }
                     , { column: "initvalue" }
-                    , { alias: "description", expr:
-                            [ ("\(.factorName)-" | asSqlLiteral)
-                            , (.weight_.params[] |
-                                "CASE WHEN \(asSqlIdent) IS NULL THEN ''
-                                      ELSE \(asSqlIdent) || ''  -- XXX CAST(... AS TEXT) unsupported by MySQL
-                                  END"
-                              )
-                            ] | join(" ||\("-" | asSqlLiteral)|| ")
+                    , { alias: "description", expr: factorWeightDescriptionSqlExpr
                       }
                     , if .function_.name != "multinomial" then
                         # TODO maybe '1' is a better one for boolean variables?
@@ -509,16 +511,45 @@ then . else
             export DEEPDIVE_LOAD_FORMAT=tsv
             export DEEPDIVE_UNLOAD_MATERIALIZED=false
 
+            # flag that signals whether to reuse weights or not
+            reuseFlag=\"$DEEPDIVE_GROUNDING_DIR\"/factor/weights.reuse
+
             # dump the weights (except the description column), converting into binary format for the inference engine
             deepdive compute \\
-                input_sql=\(
+                input_sql=\"$(if [[ -e \"$reuseFlag\" ]]; then
+                    echo \(
+                    # dump weights with initvalue from previously learned ones
+                    { SELECT:
+                        [ { table: "w", column: "id" }
+                        , { expr: "CASE WHEN w.isfixed THEN 1 ELSE 0 END" }
+                        , { expr: "COALESCE(reuse.weight, w.initvalue, 0)" }
+                        ]
+                    , FROM: [ { alias: "w", table: .weightsTableForDumping } ]
+                    , JOIN: { LEFT_OUTER: { alias: "reuse", table: deepdiveReuseWeightsTable }
+                            , ON: { and: [ { eq: [ { table: "reuse", column: "description" }
+                                                 , { expr: factorWeightDescriptionSqlExpr }
+                                                 ] }
+                                         , if .function_.name == "multinomial" then
+                                           { or: [ { isNull: { table: "reuse", column: "categories" } }
+                                                   , { eq: [ { table: "reuse", column: "categories" }
+                                                           , { table: "w",     column: "categories" }
+                                                           ] }
+                                                 ] }
+                                           else empty end
+                                         ] }
+                            }
+                    } | asSql | @sh)
+                else
+                    echo \(
+                    # dump weights from scratch
                     { SELECT:
                         [ { column: "id" }
                         , { expr: "CASE WHEN isfixed THEN 1 ELSE 0 END" }
                         , { expr: "COALESCE(initvalue, 0)" }
                         ]
                     , FROM: [ { table: .weightsTableForDumping } ]
-                    } | asSql | @sh) \\
+                    } | asSql | @sh)
+                fi)\" \\
                 command=\("
                     format_converter weight /dev/stdin >(pbzip2 >weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2)
                 " | @sh) \\

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -45,13 +45,14 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                 flatten() { find -L \"$@\" -type f -exec pbzip2 -c -d -k {} +; }
                 \($deepdive.sampler.sampler_cmd // "sampler-dw") \\
                     gibbs \\
-                    -l 0 \\
                     -w <(flatten factorgraph/weights) \\
                     -v <(flatten factorgraph/variables) \\
                     -f <(flatten factorgraph/factors) \\
                     -m factorgraph/meta \\
                     -o weights \\
-                    \($deepdive.sampler.sampler_args // "#")
+                    \($deepdive.sampler.sampler_args // "") \\
+                    -l 0 \\
+                    #
                 mkdir -p probabilities
                 mv -f weights/inference_result.out.text probabilities/
             fi

--- a/compiler/compile-config/constants.jq
+++ b/compiler/compile-config/constants.jq
@@ -6,6 +6,7 @@ def deepdiveVariableIdColumn                :  "id"                             
 def deepdiveGlobalHoldoutTable              :  "dd_graph_variables_holdout"     ;
 def deepdiveGlobalObservationTable          :  "dd_graph_variables_observation" ;
 def deepdiveGlobalWeightsTable              :  "dd_graph_weights"               ;
+def deepdiveReuseWeightsTable               :  "dd_graph_weights_reuse"         ;
 def deepdivePrefixForFactorsTable           :  "dd_query_"                      ;  # TODO correct prefix to dd_factors_?
 def deepdivePrefixForWeightsTable           :  "dd_weights_"                    ;
 def deepdivePrefixForMultinomialWeightsTable:  "dd_weightsmulti_"               ;

--- a/compiler/compile-config/sql.jq
+++ b/compiler/compile-config/sql.jq
@@ -84,6 +84,8 @@ def asSqlCondition:
     (.lt | asSqlBinaryComparison("<" )) //
     (.isNull   | nullOr("\(asSqlExpr) IS NULL")) //
     (.isntNull | nullOr("\(asSqlExpr) IS NOT NULL")) //
+    (.and | nullOr(    mapJoinString(""; asSqlCondition; " AND "))   ) //
+    (.or  | nullOr("(\(mapJoinString(""; asSqlCondition;  " OR ")))")) //
     error("Unrecognized SQL condition \(tostring)");
 # a more structured way to generate a SQL (Structured! Query Language) SELECT query than assembling strings
 # which turns an object in a particular format into SQL, taking care of many escaping issues

--- a/database/db-driver/postgresql/db-create-view-as
+++ b/database/db-driver/postgresql/db-create-view-as
@@ -17,6 +17,6 @@ Query=$1; shift
 
 viewDef=" AS $Query"
 
-[[ -n $CREATE_IF_NOT_EXISTS ]] || db-execute "DROP $DROP_TABLE_TYPE TABLE $View" &>/dev/null || true
-[[ -n $CREATE_IF_NOT_EXISTS ]] || db-execute "DROP $DROP_VIEW_TYPE  VIEW  $View" &>/dev/null || true
+[[ -n $CREATE_IF_NOT_EXISTS ]] || db-execute "DROP $DROP_TABLE_TYPE TABLE $View CASCADE" &>/dev/null || true
+[[ -n $CREATE_IF_NOT_EXISTS ]] || db-execute "DROP $DROP_VIEW_TYPE  VIEW  $View CASCADE" &>/dev/null || true
 exec db-execute "CREATE $CREATE_VIEW_TYPE VIEW ${CREATE_IF_NOT_EXISTS:+IF NOT EXISTS} $View $viewDef $CREATE_VIEW_EXTRA_CLAUSES"

--- a/examples/chunking/.gitignore
+++ b/examples/chunking/.gitignore
@@ -1,3 +1,4 @@
 /run
+/snapshot
 /result/output
 /result/result

--- a/examples/ocr/.gitignore
+++ b/examples/ocr/.gitignore
@@ -1,3 +1,4 @@
 /run
+/snapshot
 /input/raw/*.csv
 /output/

--- a/examples/smoke/.gitignore
+++ b/examples/smoke/.gitignore
@@ -1,1 +1,2 @@
 /run
+/snapshot

--- a/examples/smoke/deepdive.conf
+++ b/examples/smoke/deepdive.conf
@@ -41,5 +41,5 @@ deepdive {
 
   calibration.holdout_fraction: 0.0
 
-  sampler.sampler_args: "-l 0 -s 10 -i 1000 -t 1 --alpha 0.01"
+  sampler.sampler_args: "-l 0 -s 10 -i 1000 --alpha 0.01"
 }

--- a/examples/spouse/.gitignore
+++ b/examples/spouse/.gitignore
@@ -1,4 +1,5 @@
 /run
+/snapshot
 /udf/bazaar
 /search
 /mindbender/*.js

--- a/examples/spouse_example/postgres/ddlog/.gitignore
+++ b/examples/spouse_example/postgres/ddlog/.gitignore
@@ -1,4 +1,5 @@
 /input/*.csv
 /input/*.tsv
 /run
+/snapshot
 /udf/bazaar

--- a/examples/spouse_example/postgres/incremental/.gitignore
+++ b/examples/spouse_example/postgres/incremental/.gitignore
@@ -3,4 +3,5 @@
 /*.deepdive.conf
 /log
 /run
+/snapshot
 /app.ddlog

--- a/examples/spouse_example/postgres/tsv_extractor/.gitignore
+++ b/examples/spouse_example/postgres/tsv_extractor/.gitignore
@@ -1,3 +1,4 @@
 /input/*.csv
 /input/*.tsv
 /run
+/snapshot

--- a/examples/table/.gitignore
+++ b/examples/table/.gitignore
@@ -1,3 +1,4 @@
 /run
+/snapshot
 /pdf_rawtables
 /tables_tmp

--- a/examples/table/deepdive.conf
+++ b/examples/table/deepdive.conf
@@ -18,5 +18,5 @@ deepdive {
 
   calibration.holdout_fraction: 0.0
 
-  sampler.sampler_args: "-l 0 -s 10 -i 1000 -t 1 --alpha 0.01"
+  sampler.sampler_args: "-l 0 -s 10 -i 1000 --alpha 0.01"
 }

--- a/inference/deepdive-model
+++ b/inference/deepdive-model
@@ -74,16 +74,24 @@ case $Command in
                         rsync -avH --delete --copy-unsafe-links run/model/factorgraph{,.done} "$dest"/
                         ;;
                     weights)
+                        # automatically load weights only if learning is already done
+                        if ! deepdive-"done" data/model/weights &&
+                             deepdive-"done" process/model/learning; then
+                            DEEPDIVE_PLAN_EDIT=false \
+                            deepdive-"do" data/model/weights
+                        fi
+                        # dump non-zero weights
                         show_progress output_from "$dest" -- \
-                        deepdive sql eval "
-                            SELECT id
-                                 , isfixed
-                                 , initvalue
-                                 , description
-                                 , categories
-                              FROM dd_graph_weights
-                             WHERE initvalue <> 0
-                        " format=csv | pbzip2 >"$dest"/dd_graph_weights.csv.bz2
+                        deepdive-sql eval "
+                            SELECT description
+                                 , ARRAY_AGG(weight)
+                                 , ARRAY_AGG(categories::text)
+                              FROM dd_inference_result_weights wo
+                                 , dd_graph_weights            wi
+                             WHERE wo.id = wi.id
+                               AND weight <> 0
+                             GROUP BY description
+                        " format=tsv | pbzip2 >"$dest"/dd_graph_weights.tsv.bz2
                         ;;
                 esac
                 # keep a LAST symlink pointing to the last

--- a/inference/deepdive-model
+++ b/inference/deepdive-model
@@ -30,7 +30,7 @@ case $Command in
         ;;
 
     learn)
-        exec deepdive-redo process/model/learning data/model/weights
+        exec deepdive-redo process/model/learning data/model/{weights,probabilities}
         ;;
 
     infer)
@@ -74,7 +74,16 @@ case $Command in
                         rsync -avH --delete --copy-unsafe-links run/model/factorgraph{,.done} "$dest"/
                         ;;
                     weights)
-                        error TODO
+                        show_progress output_from "$dest" -- \
+                        deepdive sql eval "
+                            SELECT id
+                                 , isfixed
+                                 , initvalue
+                                 , description
+                                 , categories
+                              FROM dd_graph_weights
+                             WHERE initvalue <> 0
+                        " format=csv | pbzip2 >"$dest"/dd_graph_weights.csv.bz2
                         ;;
                 esac
                 # keep a LAST symlink pointing to the last

--- a/inference/deepdive-model
+++ b/inference/deepdive-model
@@ -85,6 +85,7 @@ case $Command in
                                 SELECT 1 WHERE EXISTS (
                                     SELECT id FROM dd_graph_weights
                                      WHERE categories IS NULL)") ]]; then
+                            # TODO parallel unload
                             show_progress output_from "$dest" -- \
                             deepdive-sql eval "
                                 SELECT description
@@ -94,26 +95,27 @@ case $Command in
                                  WHERE wo.id = wi.id
                                    AND weight <> 0
                                    AND categories IS NULL -- to rule out multinomial
-                            " format=tsv | pbzip2 >"$dest"/dd_graph_weights.tsv.bz2
+                            " format=tsv | pbzip2 >"$dest"/dd_weights.tsv.bz2
                         fi
                         # dump non-zero weights for multinomial factors
                         if [[ -n $(deepdive-sql eval "
                                 SELECT 1 WHERE EXISTS (
                                     SELECT id FROM dd_graph_weights
                                      WHERE categories IS NOT NULL)") ]]; then
+                            # TODO parallel unload
                             # XXX ARRAY_AGG is postgres specific
                             show_progress output_from "$dest" -- \
                             deepdive-sql eval "
                                 SELECT description
+                                     , ARRAY_AGG(categories::TEXT)
                                      , ARRAY_AGG(weight)
-                                     , ARRAY_AGG(categories::text)
                                   FROM dd_inference_result_weights wo
                                      , dd_graph_weights            wi
                                  WHERE wo.id = wi.id
                                    AND weight <> 0
                                    AND categories IS NOT NULL -- to include multinomial only
                                  GROUP BY description
-                            " format=tsv | pbzip2 >"$dest"/dd_graph_weights.multinomial.tsv.bz2
+                            " format=tsv | pbzip2 >"$dest"/dd_weights.multinomial.tsv.bz2
                         fi
                         ;;
                 esac
@@ -149,7 +151,33 @@ case $Command in
                                 rsync -avH --delete --copy-unsafe-links "$src"/factorgraph{,.done} run/model/
                                 ;;
                             weights)
-                                error TODO
+                                weightTableName=dd_reuse_weights_"$Name"
+                                deepdive create table "$weightTableName" "description:TEXT" "category:TEXT" "weight:DOUBLE PRECISION"
+                                for weightFile in "$src"/dd_weights{,.multinomial}.tsv.bz2; do
+                                    [[ -e "$weightFile" ]] || continue
+                                    case $weightFile in
+                                        *.multinomial.tsv.bz2)
+                                            # first load the grouped data from file
+                                            deepdive create table "${weightTableName}_array" "description:TEXT" "categories::TEXT[]" "weights:DOUBLE PRECISION[]"
+                                            # TODO parallel load
+                                            deepdive load "${weightTableName}_array" "$weightFile"
+                                            # explode the group
+                                            deepdive sql "INSERT INTO $weightTableName
+                                                SELECT description
+                                                     , UNNEST(categories) AS category
+                                                     , UNNEST(weights)    AS weight
+                                                  FROM ${weightTableName}_array
+                                            "
+                                            deepdive sql "DROP TABLE ${weightTableName}_array"
+                                            ;;
+                                        *.tsv.bz2)
+                                            # TODO parallel load
+                                            deepdive load "$weightTableName" "$weightFile"
+                                            ;;
+                                        *)
+                                            error "$weightFile: Unsupported weights file"
+                                    esac
+                                done
                                 ;;
                         esac
                         ;;

--- a/inference/deepdive-model
+++ b/inference/deepdive-model
@@ -187,7 +187,7 @@ case $Command in
                                             ;;
                                         *.tsv.bz2)
                                             # TODO parallel load
-                                            deepdive load "$weightTableName" "$weightFile"
+                                            deepdive load "$weightTableName(description,weight)" "$weightFile"
                                             ;;
                                         *)
                                             error "$weightFile: Unsupported weights file"
@@ -196,10 +196,9 @@ case $Command in
                                 # dump the new weights with corresponding id in the current factor graph
                                 mkdir -p "$(dirname "$weightsReuseFlag")"
                                 touch "$weightsReuseFlag"
-                                DEEPDIVE_PLAN_EDIT=false \
                                 deepdive-redo $(deepdive plan 2>&1 | grep '/dump_weights$') process/grounding/combine_factorgraph
-                                # mark weights as done (as well as learning) to make sure deepdive-model infer skips learning
-                                deepdive-mark done data/model/weights
+                                # mark learning and weights as done to make sure `deepdive-model infer` skips it
+                                deepdive-mark done model/weights
                                 ;;
                         esac
                         ;;
@@ -226,8 +225,7 @@ case $Command in
                         ;;
                     weights)
                         rm -fv run/model/grounding/factor/weights.reuse
-                        DEEPDIVE_PLAN_EDIT=false \
-                        deepdive-redo $(deepdive plan 2>&1 | grep '/dump_weights$') process/grounding/combine_factorgraph
+                        deepdive-mark todo $(deepdive plan 2>&1 | grep '/dump_weights$')
                         ;;
                 esac
                 ;;

--- a/inference/deepdive-model
+++ b/inference/deepdive-model
@@ -2,18 +2,22 @@
 # deepdive-model -- Supports working with the statistical inference model
 #
 # > deepdive model ground
-# > deepdive model factorgraph
-# > deepdive model factorgraph keep [NAME]
-# > deepdive model factorgraph load [NAME]
-# > deepdive model factorgraph drop [NAME]
+# > deepdive model factorgraph init
+# > deepdive model factorgraph list
+# > deepdive model factorgraph keep  [NAME]
+# > deepdive model factorgraph reuse [NAME]
+# > deepdive model factorgraph drop  [NAME]
 #
 # > deepdive model learn
-# > deepdive model weights
-# > deepdive model weights keep [NAME]
-# > deepdive model weights load [NAME]
-# > deepdive model weights drop [NAME]
+# > deepdive model weights init
+# > deepdive model weights list
+# > deepdive model weights keep  [NAME]
+# > deepdive model weights reuse [NAME]
+# > deepdive model weights drop  [NAME]
 #
 # > deepdive model infer
+#
+# > deepdive model calibration
 ##
 set -euo pipefail
 
@@ -34,7 +38,11 @@ case $Command in
         ;;
 
     infer)
-        exec deepdive-redo process/model/inference data/model/probabilities
+        exec deepdive-redo process/model/inference data/model/{weights,probabilities}
+        ;;
+
+    calibration)
+        exec deepdive-redo model/calibration-plots
         ;;
 
     # managment of artifacts related to the model
@@ -70,6 +78,8 @@ case $Command in
                 esac
                 case $What in
                     factorgraph)
+                        # TODO keep database tables for grounding as well
+                        # TODO rsync run/model/grounding as well
                         # TODO use cp -al instead of duplicating with rsync?
                         rsync -avH --delete --copy-unsafe-links run/model/factorgraph{,.done} "$dest"/
                         ;;
@@ -124,7 +134,7 @@ case $Command in
                 ln -sfnv "$Name" snapshot/model/"$What"/LAST
                 ;;
 
-            load|drop)
+            reuse|drop)
                 if [[ $# -eq 0 ]]; then
                     Name=LAST
                     [[ -e "$DEEPDIVE_APP/snapshot/model/$What/$Name" ]] ||
@@ -143,16 +153,20 @@ case $Command in
                         error "\`deepdive keep $What $Name\` has never run or $Name got removed"
                 fi
                 case $Command in
-                    load)
+                    reuse)
                         case $What in
                             factorgraph)
                                 cd "$DEEPDIVE_APP"
                                 # TODO use (relative) symlink or cp -al instead of duplicating with rsync?
                                 rsync -avH --delete --copy-unsafe-links "$src"/factorgraph{,.done} run/model/
+                                # TODO load all table for grounding as well
                                 ;;
                             weights)
-                                weightTableName=dd_reuse_weights_"$Name"
-                                deepdive create table "$weightTableName" "description:TEXT" "category:TEXT" "weight:DOUBLE PRECISION"
+                                # TODO load into a unique table, then create a view with the following name
+                                weightTableName=dd_graph_weights_reuse
+                                weightsReuseFlag="$DEEPDIVE_APP"/run/model/grounding/factor/weights.reuse
+                                deepdive create table "$weightTableName" "description:TEXT" "categories:TEXT" "weight:DOUBLE PRECISION"
+                                rm -f "$weightsReuseFlag"
                                 for weightFile in "$src"/dd_weights{,.multinomial}.tsv.bz2; do
                                     [[ -e "$weightFile" ]] || continue
                                     case $weightFile in
@@ -162,9 +176,10 @@ case $Command in
                                             # TODO parallel load
                                             deepdive load "${weightTableName}_array" "$weightFile"
                                             # explode the group
+                                            # XXX UNNEST is postgres-specific
                                             deepdive sql "INSERT INTO $weightTableName
                                                 SELECT description
-                                                     , UNNEST(categories) AS category
+                                                     , UNNEST(categories) AS categories
                                                      , UNNEST(weights)    AS weight
                                                   FROM ${weightTableName}_array
                                             "
@@ -178,6 +193,13 @@ case $Command in
                                             error "$weightFile: Unsupported weights file"
                                     esac
                                 done
+                                # dump the new weights with corresponding id in the current factor graph
+                                mkdir -p "$(dirname "$weightsReuseFlag")"
+                                touch "$weightsReuseFlag"
+                                DEEPDIVE_PLAN_EDIT=false \
+                                deepdive-redo $(deepdive plan 2>&1 | grep '/dump_weights$') process/grounding/combine_factorgraph
+                                # mark weights as done (as well as learning) to make sure deepdive-model infer skips learning
+                                deepdive-mark done data/model/weights
                                 ;;
                         esac
                         ;;
@@ -192,6 +214,21 @@ case $Command in
                             # or just remove all files
                             rm -rfv "$src"/
                         fi
+                esac
+                ;;
+
+            init)
+                cd "$DEEPDIVE_APP"
+                case $What in
+                    factorgraph)
+                        deepdive-mark todo process/grounding/variable_id_partition
+                        rm -rfv run/model/{grounding,factorgraph{,.done}}
+                        ;;
+                    weights)
+                        rm -fv run/model/grounding/factor/weights.reuse
+                        DEEPDIVE_PLAN_EDIT=false \
+                        deepdive-redo $(deepdive plan 2>&1 | grep '/dump_weights$') process/grounding/combine_factorgraph
+                        ;;
                 esac
                 ;;
 

--- a/inference/deepdive-model
+++ b/inference/deepdive-model
@@ -5,11 +5,13 @@
 # > deepdive model factorgraph
 # > deepdive model factorgraph keep [NAME]
 # > deepdive model factorgraph load [NAME]
+# > deepdive model factorgraph drop [NAME]
 #
 # > deepdive model learn
 # > deepdive model weights
 # > deepdive model weights keep [NAME]
 # > deepdive model weights load [NAME]
+# > deepdive model weights drop [NAME]
 #
 # > deepdive model infer
 ##
@@ -44,7 +46,7 @@ case $Command in
                 container="$DEEPDIVE_APP"/snapshot/model/"$What"
                 if [[ -d "$container" ]]; then
                     cd "$container"
-                    ls
+                    ls -t
                 fi
                 ;;
 
@@ -80,15 +82,15 @@ case $Command in
                 ln -sfnv "$Name" snapshot/model/"$What"/LAST
                 ;;
 
-            load)
+            load|drop)
                 if [[ $# -eq 0 ]]; then
-                    Name=LAST."$What"
-                    [[ -e "$DEEPDIVE_APP/snapshot/run/$Name" ]] ||
-                        error "\`deepdive $What keep\` has never been run yet"
+                    Name=LAST
+                    [[ -e "$DEEPDIVE_APP/snapshot/model/$What/$Name" ]] ||
+                        error "\`deepdive $What keep\` has never been run"
                 else
                     Name=$1; shift
                 fi
-                # determine where to load from
+                # determine the actual artifact
                 if [[ -d "$Name" ]]; then
                     src=$(cd "$Name" && pwd)
                     cd "$DEEPDIVE_APP"
@@ -98,15 +100,30 @@ case $Command in
                     [[ -e $src ]] ||
                         error "\`deepdive keep $What $Name\` has never run or $Name got removed"
                 fi
-                case $What in
-                    factorgraph)
-                        cd "$DEEPDIVE_APP"
-                        # TODO use (relative) symlink or cp -al instead of duplicating with rsync?
-                        rsync -avH --delete --copy-unsafe-links "$src"/factorgraph{,.done} run/model/
+                case $Command in
+                    load)
+                        case $What in
+                            factorgraph)
+                                cd "$DEEPDIVE_APP"
+                                # TODO use (relative) symlink or cp -al instead of duplicating with rsync?
+                                rsync -avH --delete --copy-unsafe-links "$src"/factorgraph{,.done} run/model/
+                                ;;
+                            weights)
+                                error TODO
+                                ;;
+                        esac
                         ;;
-                    weights)
-                        error TODO
-                        ;;
+                    drop)
+                        if [[ "$src" -ef snapshot/model/"$What"/LAST ]]; then
+                            rm -rfv "$src"/
+                            # replace LAST symlink if dropping that one
+                            next=$(deepdive-model "$What" list | grep -vxF LAST | head -1)
+                            [[ -z $next ]] ||
+                                ln -sfnv "$next" snapshot/model/"$What"/LAST
+                        else
+                            # or just remove all files
+                            rm -rfv "$src"/
+                        fi
                 esac
                 ;;
 

--- a/inference/deepdive-model
+++ b/inference/deepdive-model
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# deepdive-model -- Supports working with the statistical inference model
+#
+# > deepdive model ground
+# > deepdive model factorgraph
+# > deepdive model factorgraph keep [NAME]
+# > deepdive model factorgraph load [NAME]
+#
+# > deepdive model learn
+# > deepdive model weights
+# > deepdive model weights keep [NAME]
+# > deepdive model weights load [NAME]
+#
+# > deepdive model infer
+##
+set -euo pipefail
+
+DEEPDIVE_APP=$(find-deepdive-app)
+export DEEPDIVE_APP
+
+[[ $# -gt 0 ]] || usage "$0" "Missing COMMAND"
+Command=$1; shift
+
+case $Command in
+    # shorthands for repeating groups of processes related to the model
+    ground)
+        exec deepdive-redo process/grounding/{variable_id_partition,combine_factorgraph}
+        ;;
+
+    learn)
+        exec deepdive-redo process/model/learning data/model/weights
+        ;;
+
+    infer)
+        exec deepdive-redo process/model/inference data/model/probabilities
+        ;;
+
+    # managment of artifacts related to the model
+    factorgraph|weights)
+        What=$Command; [[ $# -gt 0 ]] || set -- list  # defaults to listing
+        Command=$1; shift
+        case $Command in
+            list)
+                container="$DEEPDIVE_APP"/snapshot/model/"$What"
+                if [[ -d "$container" ]]; then
+                    cd "$container"
+                    ls
+                fi
+                ;;
+
+            keep)
+                if [[ $# -eq 0 ]]; then
+                    Name=$(date +%Y%m%d.%H%M%S)
+                else
+                    Name=$1; shift
+                fi
+                # determine where to keep: either in snapshot/model/ or $Name itself if it's a path
+                case $Name in
+                    */*)
+                        mkdir -p "$Name"
+                        dest=$(cd "$Name" && pwd)
+                        cd "$DEEPDIVE_APP"
+                        ;;
+                    *)
+                        cd "$DEEPDIVE_APP"
+                        dest=snapshot/model/"$What"/"$Name"
+                        mkdir -p "$dest"
+                esac
+                case $What in
+                    factorgraph)
+                        # TODO use cp -al instead of duplicating with rsync?
+                        rsync -avH --delete --copy-unsafe-links run/model/factorgraph{,.done} "$dest"/
+                        ;;
+                    weights)
+                        error TODO
+                        ;;
+                esac
+                # keep a LAST symlink pointing to the last
+                mkdir -p snapshot/model/"$What"
+                ln -sfnv "$Name" snapshot/model/"$What"/LAST
+                ;;
+
+            load)
+                if [[ $# -eq 0 ]]; then
+                    Name=LAST."$What"
+                    [[ -e "$DEEPDIVE_APP/snapshot/run/$Name" ]] ||
+                        error "\`deepdive $What keep\` has never been run yet"
+                else
+                    Name=$1; shift
+                fi
+                # determine where to load from
+                if [[ -d "$Name" ]]; then
+                    src=$(cd "$Name" && pwd)
+                    cd "$DEEPDIVE_APP"
+                else
+                    cd "$DEEPDIVE_APP"
+                    src="snapshot/model/$What/$Name"
+                    [[ -e $src ]] ||
+                        error "\`deepdive keep $What $Name\` has never run or $Name got removed"
+                fi
+                case $What in
+                    factorgraph)
+                        cd "$DEEPDIVE_APP"
+                        # TODO use (relative) symlink or cp -al instead of duplicating with rsync?
+                        rsync -avH --delete --copy-unsafe-links "$src"/factorgraph{,.done} run/model/
+                        ;;
+                    weights)
+                        error TODO
+                        ;;
+                esac
+                ;;
+
+            *)
+                usage "$0" "deepdive model: $What $Command: Unrecognized command"
+        esac
+        ;;
+
+    *)
+        usage "$0" "$Command: Unrecognized command"
+esac

--- a/inference/deepdive-model
+++ b/inference/deepdive-model
@@ -80,18 +80,41 @@ case $Command in
                             DEEPDIVE_PLAN_EDIT=false \
                             deepdive-"do" data/model/weights
                         fi
-                        # dump non-zero weights
-                        show_progress output_from "$dest" -- \
-                        deepdive-sql eval "
-                            SELECT description
-                                 , ARRAY_AGG(weight)
-                                 , ARRAY_AGG(categories::text)
-                              FROM dd_inference_result_weights wo
-                                 , dd_graph_weights            wi
-                             WHERE wo.id = wi.id
-                               AND weight <> 0
-                             GROUP BY description
-                        " format=tsv | pbzip2 >"$dest"/dd_graph_weights.tsv.bz2
+                        # dump non-zero weights for boolean factors
+                        if [[ -n $(deepdive-sql eval "
+                                SELECT 1 WHERE EXISTS (
+                                    SELECT id FROM dd_graph_weights
+                                     WHERE categories IS NULL)") ]]; then
+                            show_progress output_from "$dest" -- \
+                            deepdive-sql eval "
+                                SELECT description
+                                     , weight
+                                  FROM dd_inference_result_weights wo
+                                     , dd_graph_weights            wi
+                                 WHERE wo.id = wi.id
+                                   AND weight <> 0
+                                   AND categories IS NULL -- to rule out multinomial
+                            " format=tsv | pbzip2 >"$dest"/dd_graph_weights.tsv.bz2
+                        fi
+                        # dump non-zero weights for multinomial factors
+                        if [[ -n $(deepdive-sql eval "
+                                SELECT 1 WHERE EXISTS (
+                                    SELECT id FROM dd_graph_weights
+                                     WHERE categories IS NOT NULL)") ]]; then
+                            # XXX ARRAY_AGG is postgres specific
+                            show_progress output_from "$dest" -- \
+                            deepdive-sql eval "
+                                SELECT description
+                                     , ARRAY_AGG(weight)
+                                     , ARRAY_AGG(categories::text)
+                                  FROM dd_inference_result_weights wo
+                                     , dd_graph_weights            wi
+                                 WHERE wo.id = wi.id
+                                   AND weight <> 0
+                                   AND categories IS NOT NULL -- to include multinomial only
+                                 GROUP BY description
+                            " format=tsv | pbzip2 >"$dest"/dd_graph_weights.multinomial.tsv.bz2
+                        fi
                         ;;
                 esac
                 # keep a LAST symlink pointing to the last

--- a/runner/compute-driver/local/compute-execute
+++ b/runner/compute-driver/local/compute-execute
@@ -128,12 +128,16 @@ if [[ -n $input_sql ]]; then
 fi
 
 # make sure all the child processes finishes without error
+pids_all=()
+[[ ${#pids_command[@]} -eq 0 ]] || pids_all+=("${pids_command[@]}")
+[[ ${#pids_load[@]}    -eq 0 ]] || pids_all+=("${pids_load[@]}"   )
+[[ ${#pids_unload[@]}  -eq 0 ]] || pids_all+=("${pids_unload[@]}" )
 all_finishes_ok() {
     local what=$1; shift
     local pid=
     for pid in "$@"; do
         wait $pid || {
-            kill -TERM "${pids_command[@]}" "${pids_load[@]}" "${pids_unload[@]}"
+            kill -TERM "${pids_all[@]}"
             error "${what:+$what: }PID $pid: finished with non-zero exit status ($?)"
         }
     done

--- a/runner/show_progress
+++ b/runner/show_progress
@@ -22,7 +22,7 @@ Options=()
 while [[ $# -gt 0 && $1 != "--" ]]; do
     Options+=("$1"); shift
 done
-[[ $1 = "--" ]] || usage "$0" "Missing -- before COMMAND"
+[[ ${1:-} = "--" ]] || usage "$0" "Missing -- before COMMAND"
 shift
 
 # map options to pv flags

--- a/shell/deepdive_bash_completion.sh
+++ b/shell/deepdive_bash_completion.sh
@@ -58,9 +58,10 @@ _deepdive() {
                             3)
                                 case ${COMP_WORDS[2]} in
                                     factorgraph|weights)
-                                        echo keep
+                                        echo init
                                         echo list
-                                        echo load
+                                        echo keep
+                                        echo reuse
                                         echo drop
                                 esac
                                 ;;

--- a/shell/deepdive_bash_completion.sh
+++ b/shell/deepdive_bash_completion.sh
@@ -49,6 +49,27 @@ _deepdive() {
                                 list_deepdive_targets
                         esac
                         ;;
+                    model)
+                        case $COMP_CWORD in
+                            2) deepdive model 2>/dev/null | sed '
+                                    /^deepdive model/!d
+                                    s/^deepdive model  *//; s/  *.*$//'
+                                ;;
+                            3)
+                                case ${COMP_WORDS[2]} in
+                                    factorgraph|weights)
+                                        echo keep
+                                        echo list
+                                        echo load
+                                esac
+                                ;;
+                            *)
+                                case ${COMP_WORDS[2]} in
+                                    factorgraph|weights)
+                                        deepdive model ${COMP_WORDS[2]} list
+                                esac
+                        esac
+                        ;;
                 esac
         esac
     `

--- a/shell/deepdive_bash_completion.sh
+++ b/shell/deepdive_bash_completion.sh
@@ -61,6 +61,7 @@ _deepdive() {
                                         echo keep
                                         echo list
                                         echo load
+                                        echo drop
                                 esac
                                 ;;
                             *)

--- a/stage.sh
+++ b/stage.sh
@@ -133,6 +133,7 @@ Darwin)
     ;;
 esac
 stage inference/format_converter                                  util/format_converter
+stage inference/deepdive-model                                    util/
 
 # DeepDive utilities
 stage util/draw_calibration_plot                                  util/

--- a/test/postgresql/chunking_example.bats
+++ b/test/postgresql/chunking_example.bats
@@ -5,13 +5,39 @@
 : ${SUBSAMPLE_NUM_WORDS_TRAIN:=5000} ${SUBSAMPLE_NUM_WORDS_TEST:=1000}
 export SUBSAMPLE_NUM_WORDS_TRAIN SUBSAMPLE_NUM_WORDS_TEST
 
+get_f1score() {
+    printf '%.0f' $(
+        result/eval.sh | tee /dev/stderr | sed -n '/^accuracy:/ s/.* FB1: *//p')
+}
+
 @test "$DBVARIANT chunking example" {
     cd "$BATS_TEST_DIRNAME"/chunking_example || skip
     DEEPDIVE_CONFIG_EXTRA='deepdive.calibration.holdout_query: "INSERT INTO dd_graph_variables_holdout(variable_id) SELECT id FROM words WHERE word_id > '${SUBSAMPLE_NUM_WORDS_TRAIN}'"' \
     deepdive compile
-    deepdive redo process/init/app data/model/{weights,probabilities}
-
-    f1score=$(printf '%.0f' $(
-        result/eval.sh | tee /dev/stderr | sed -n '/^accuracy:/ s/.* FB1: *//p'))
+    deepdive model weights init
+    deepdive redo process/init/app data/model/probabilities
+    f1score=$(get_f1score)
+    echo "f1score = $f1score"
     [[ $f1score -ge 80 ]]
+}
+
+@test "$DBVARIANT chunking example reuse weights" {
+    cd "$BATS_TEST_DIRNAME"/chunking_example || skip
+    # keep the learned weights from a small corpus
+    deepdive model weights keep
+
+    # load larger test corpus
+    SUBSAMPLE_NUM_WORDS_TRAIN=0 SUBSAMPLE_NUM_WORDS_TEST=5000 \
+    deepdive redo words_raw
+
+    # reuse the weights (to skip learning)
+    deepdive model weights reuse  # taking care of all extraction and grounding for larger data
+
+    # and do inference
+    deepdive redo data/model/probabilities
+
+    # check quality
+    f1score=$(get_f1score)
+    echo "f1score = $f1score"
+    [[ $f1score -ge 75 ]]
 }


### PR DESCRIPTION
Shorthand commands for repeating a group of processes related to inference.
* `deepdive model ground`
* `deepdive model learn`
* `deepdive model infer`

Commands for keeping and reusing weights.
* `deepdive model weights keep`
* `deepdive model weights reuse`
* `deepdive model weights list`
* `deepdive model weights drop`
* `deepdive model weights init`

(These work with factor graphs as well if you replace `weights` with `factorgraph` but more bits should be kept to make it fully useful/meaningful, e.g., speeding up grounding, etc.  Currently it just stashes/restores the dumped factorgraph binaries but that's quite useless unless we keep around the database tables for grounding as well.)

Here's a hypothetical workflow:
```bash
deepdive do init/app

# learn weights from a small corpus and keep it for future reuse
deepdive create table articles
deepdive load articles /data/small/corpus.tsv.bz2
deepdive mark new articles
deepdive model learn  # taking care of all necessary extraction and grounding
deepdive model weights keep foo

# load larger corpus
deepdive create table articles
deepdive load articles /data/LARGE/corpus.tsv.bz2
deepdive mark new articles

# reuse the weights (skipping learning) and do inference
deepdive model weights reuse foo  # taking care of all extraction and grounding for larger data
deepdive model infer
```

I'll soon add a test that looks like above for a few of our examples (either in this PR or another).

Closes #463