### PR TITLE
Fixes bug in fast_seqassign for Greenplum

### DIFF
--- a/database/db-driver/greenplum/db-assign_sequential_id
+++ b/database/db-driver/greenplum/db-assign_sequential_id
@@ -17,73 +17,66 @@ Table=$1 Column=$2 BeginId=$3 Increment=${4:-1}
 db-execute "CREATE LANGUAGE plpgsql;" || true
 db-execute "CREATE LANGUAGE plpythonu;" || true
 db-execute "
-    CREATE OR REPLACE FUNCTION clear_count_1(sid INT) RETURNS INT AS
-    \$\$
-    if '__count_1' in SD:
-      SD['__count_1'] = -1
-      return 1
-    return 0 # XXX why return a confusing 0 when it still counts toward COUNT()?
+    CREATE OR REPLACE FUNCTION fast_seqassign_init()
+    RETURNS INT AS \$\$
+      if 'cumulative_cnt' in SD:
+        SD.pop('cumulative_cnt')
+      return 0
     \$\$ LANGUAGE plpythonu;
 
-    CREATE OR REPLACE FUNCTION updateid(startid BIGINT, increment BIGINT, sid INT, sids INT[], base_ids BIGINT[], base_ids_noagg BIGINT[]) RETURNS BIGINT AS
-    \$\$
-    if '__count_1' in SD:
-      a = SD['__count_2']
-      b = SD['__count_1']
-      SD['__count_2'] = SD['__count_2'] - 1
-      if SD['__count_2'] < 0:
-        SD.pop('__count_1')
-
-    else:
-      for i in range(0, len(sids)):
-        if sids[i] == sid:
-          SD['__count_1'] = base_ids[i] - 1
-          SD['__count_2'] = base_ids_noagg[i] - 1
-      a = SD['__count_2']
-      b = SD['__count_1']
-      SD['__count_2'] = SD['__count_2'] - 1
-      if SD['__count_2'] < 0:
-        SD.pop('__count_1')
-
-    return startid + increment*(b-a)
-
+    CREATE OR REPLACE FUNCTION fast_seqassign_next(startid BIGINT, increment BIGINT, this_gpsid INT, gpsids INT[], cumulative_cnts BIGINT[], cnts BIGINT[])
+    RETURNS BIGINT AS \$\$
+      if 'cumulative_cnt' not in SD:
+        for gpsid, cumulative_cnt, cnt in zip(gpsids, cumulative_cnts, cnts):
+          if gpsid == this_gpsid:
+            # assignment is done using the cumulative count for this segment and a decrementing counter from the size of this segment down to one
+            SD['cumulative_cnt'] = cumulative_cnt
+            SD['remaining'] = cnt
+            break
+      if 'cumulative_cnt' in SD and SD['remaining'] > 0:
+        id = startid + increment * (SD['cumulative_cnt'] - SD['remaining'])
+        SD['remaining'] = SD['remaining'] - 1
+        if SD['remaining'] <= 0:
+          SD.pop('cumulative_cnt')
+        return id
+      else:
+        # XXX no segment was found
+        raise plpy.ERROR('No non-empty id range was assigned for segment %s in the initial partition' % str(this_gpsid))
     \$\$ LANGUAGE plpythonu;
 
-    CREATE OR REPLACE FUNCTION fast_seqassign(tname character varying, cname character varying, startid bigint, increment bigint) RETURNS TEXT AS
-    \$\$
+    CREATE OR REPLACE FUNCTION fast_seqassign(tname CHARACTER VARYING, cname CHARACTER VARYING, startid BIGINT, increment BIGINT)
+    RETURNS TEXT AS \$\$
     BEGIN
-      EXECUTE 'DROP TABLE IF EXISTS tmp_gpsid_count       CASCADE;';
-      EXECUTE 'DROP TABLE IF EXISTS tmp_gpsid_count_noagg CASCADE;';
-      EXECUTE 'CREATE TABLE tmp_gpsid_count       AS SELECT gp_segment_id AS sid, COUNT(clear_count_1(gp_segment_id)) AS base_id FROM ' || QUOTE_IDENT(tname) || ' GROUP BY gp_segment_id ORDER BY sid DISTRIBUTED BY (sid);';
-      EXECUTE 'CREATE TABLE tmp_gpsid_count_noagg AS SELECT *                                                                    FROM tmp_gpsid_count                                                  DISTRIBUTED BY (sid);';
-      EXECUTE 'UPDATE tmp_gpsid_count AS t SET base_id = (SELECT SUM(base_id) FROM tmp_gpsid_count AS t2 WHERE t2.sid <= t.sid);';
-      RAISE NOTICE 'EXECUTING _fast_seqassign()...';
-      EXECUTE 'SELECT * FROM _fast_seqassign(''' || QUOTE_IDENT(tname) || ''', ''' || QUOTE_IDENT(cname) || ''', ' || startid || ', ' || increment || ');';
-      RETURN '';
+      EXECUTE 'CREATE TEMPORARY VIEW dd_tmp_id_ranges_by_gpsid AS
+               SELECT gpsid
+                    , cnt
+                    , SUM(cnt) OVER (ORDER BY gpsid) AS cumulative_cnt
+                 FROM (
+                    SELECT gp_segment_id AS gpsid
+                         , COUNT(1)      AS cnt
+                      FROM ' || QUOTE_IDENT(tname) || '
+                     GROUP BY gpsid
+                     ORDER BY gpsid
+                 ) histogram;';
+      DECLARE
+        gpsids          INT[]    := ARRAY(SELECT gpsid          FROM dd_tmp_id_ranges_by_gpsid ORDER BY gpsid);
+        cumulative_cnts BIGINT[] := ARRAY(SELECT cumulative_cnt FROM dd_tmp_id_ranges_by_gpsid ORDER BY gpsid);
+        cnts            BIGINT[] := ARRAY(SELECT cnt            FROM dd_tmp_id_ranges_by_gpsid ORDER BY gpsid);
+      BEGIN
+        EXECUTE 'SELECT fast_seqassign_init();';
+        EXECUTE 'UPDATE ' || tname || ' SET ' || cname || ' = fast_seqassign_next(
+            ' || startid || ',
+            ' || increment || ',
+            gp_segment_id,
+            ARRAY[' || ARRAY_TO_STRING(         gpsids, ',')::TEXT || '],
+            ARRAY[' || ARRAY_TO_STRING(cumulative_cnts, ',')::TEXT || '],
+            ARRAY[' || ARRAY_TO_STRING(           cnts, ',')::TEXT || ']
+          );';
+        RETURN 'fast_seqassign done for segments [' || ARRAY_TO_STRING(gpsids, ',') || ']' ||
+               ' with counts [' || ARRAY_TO_STRING(cnts, ',') || ']';
+      END;
     END;
     \$\$ LANGUAGE 'plpgsql';
-
-    CREATE OR REPLACE FUNCTION _fast_seqassign(tname CHARACTER VARYING, cname CHARACTER VARYING, startid BIGINT, increment BIGINT)
-    RETURNS TEXT AS
-    \$\$
-    DECLARE
-      sids              INT[]    := ARRAY(SELECT sid     FROM tmp_gpsid_count       ORDER BY sid);
-      base_ids          BIGINT[] := ARRAY(SELECT base_id FROM tmp_gpsid_count       ORDER BY sid);
-      base_ids_noagg    BIGINT[] := ARRAY(SELECT base_id FROM tmp_gpsid_count_noagg ORDER BY sid);
-      tsids             TEXT;
-      tbase_ids         TEXT;
-      tbase_ids_noagg   TEXT;
-    BEGIN
-      SELECT INTO tsids           ARRAY_TO_STRING(sids, ',');
-      SELECT INTO tbase_ids       ARRAY_TO_STRING(base_ids, ',');
-      SELECT INTO tbase_ids_noagg ARRAY_TO_STRING(base_ids_noagg, ',');
-      IF ('UPDATE ' || tname || ' SET ' || cname || ' = updateid(' || startid || ', ' || increment || ', gp_segment_id, ARRAY[' || tsids || '], ARRAY[' || tbase_ids || '], ARRAY[' || tbase_ids_noagg || ']);')::TEXT IS NOT NULL THEN
-        EXECUTE 'UPDATE ' || tname || ' SET ' || cname || ' = updateid(' || startid || ', ' || increment || ', gp_segment_id, ARRAY[' || tsids || '], ARRAY[' || tbase_ids || '], ARRAY[' || tbase_ids_noagg || ']);';
-      END IF;
-      RETURN '';
-    END;
-    \$\$
-    LANGUAGE 'plpgsql';
 
     SELECT fast_seqassign('$Table', '$Column', $BeginId, $Increment);
 " && exit

--- a/database/db-driver/greenplum/db-assign_sequential_id
+++ b/database/db-driver/greenplum/db-assign_sequential_id
@@ -10,6 +10,8 @@ set -euo pipefail
 [[ $# -gt 2 ]] || usage "$0" "Missing BEGIN_ID"
 Table=$1 Column=$2 BeginId=$3 Increment=${4:-1}
 
+[[ $Increment -ne 0 ]] || usage "$0" "INCREMENT must be non-zero"
+
 # Use Greenplum PL/pgSQL and PL/Python UDFs to assign IDs fast
 # See: http://www.postgresql.org/docs/8.2/static/sql-createlanguage.html
 # See: http://www.postgresql.org/docs/8.2/static/plpgsql-overview.html

--- a/database/db-driver/greenplum/db-assign_sequential_id
+++ b/database/db-driver/greenplum/db-assign_sequential_id
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # db-assign_sequential_id -- Assigns a unique integer to every row for a table using PostgreSQL sequence generator
 # > eval "$(db-parse "$url")"
-# > db-assign_sequential_id TABLE COLUMN BEGIN_ID
+# > db-assign_sequential_id TABLE COLUMN BEGIN_ID [INCREMENT]
 ##
 set -euo pipefail
 
 [[ $# -gt 0 ]] || usage "$0" "Missing TABLE"
 [[ $# -gt 1 ]] || usage "$0" "Missing COLUMN"
 [[ $# -gt 2 ]] || usage "$0" "Missing BEGIN_ID"
-Table=$1 Column=$2 BeginId=$3
+Table=$1 Column=$2 BeginId=$3 Increment=${4:-1}
 
 # Use Greenplum PL/pgSQL and PL/Python UDFs to assign IDs fast
 # See: http://www.postgresql.org/docs/8.2/static/sql-createlanguage.html
@@ -17,15 +17,15 @@ Table=$1 Column=$2 BeginId=$3
 db-execute "CREATE LANGUAGE plpgsql;" || true
 db-execute "CREATE LANGUAGE plpythonu;" || true
 db-execute "
-    CREATE OR REPLACE FUNCTION clear_count_1(sid int) RETURNS int AS
+    CREATE OR REPLACE FUNCTION clear_count_1(sid INT) RETURNS INT AS
     \$\$
     if '__count_1' in SD:
       SD['__count_1'] = -1
       return 1
-    return 0
+    return 0 # XXX why return a confusing 0 when it still counts toward COUNT()?
     \$\$ LANGUAGE plpythonu;
 
-    CREATE OR REPLACE FUNCTION updateid(startid bigint, sid int, sids int[], base_ids bigint[], base_ids_noagg bigint[]) RETURNS bigint AS
+    CREATE OR REPLACE FUNCTION updateid(startid BIGINT, increment BIGINT, sid INT, sids INT[], base_ids BIGINT[], base_ids_noagg BIGINT[]) RETURNS BIGINT AS
     \$\$
     if '__count_1' in SD:
       a = SD['__count_2']
@@ -33,7 +33,7 @@ db-execute "
       SD['__count_2'] = SD['__count_2'] - 1
       if SD['__count_2'] < 0:
         SD.pop('__count_1')
-      return startid+b-a
+
     else:
       for i in range(0, len(sids)):
         if sids[i] == sid:
@@ -44,47 +44,48 @@ db-execute "
       SD['__count_2'] = SD['__count_2'] - 1
       if SD['__count_2'] < 0:
         SD.pop('__count_1')
-      return startid+b-a
+
+    return startid + increment*(b-a)
 
     \$\$ LANGUAGE plpythonu;
 
-    CREATE OR REPLACE FUNCTION fast_seqassign(tname character varying, cname character varying, startid bigint) RETURNS TEXT AS
+    CREATE OR REPLACE FUNCTION fast_seqassign(tname character varying, cname character varying, startid bigint, increment bigint) RETURNS TEXT AS
     \$\$
     BEGIN
-      EXECUTE 'drop table if exists tmp_gpsid_count cascade;';
-      EXECUTE 'drop table if exists tmp_gpsid_count_noagg cascade;';
-      EXECUTE 'create table tmp_gpsid_count as select gp_segment_id as sid, count(clear_count_1(gp_segment_id)) as base_id from ' || quote_ident(tname) || ' group by gp_segment_id order by sid distributed by (sid);';
-      EXECUTE 'create table tmp_gpsid_count_noagg as select * from tmp_gpsid_count distributed by (sid);';
-      EXECUTE 'update tmp_gpsid_count as t set base_id = (SELECT SUM(base_id) FROM tmp_gpsid_count as t2 WHERE t2.sid <= t.sid);';
+      EXECUTE 'DROP TABLE IF EXISTS tmp_gpsid_count       CASCADE;';
+      EXECUTE 'DROP TABLE IF EXISTS tmp_gpsid_count_noagg CASCADE;';
+      EXECUTE 'CREATE TABLE tmp_gpsid_count       AS SELECT gp_segment_id AS sid, COUNT(clear_count_1(gp_segment_id)) AS base_id FROM ' || QUOTE_IDENT(tname) || ' GROUP BY gp_segment_id ORDER BY sid DISTRIBUTED BY (sid);';
+      EXECUTE 'CREATE TABLE tmp_gpsid_count_noagg AS SELECT *                                                                    FROM tmp_gpsid_count                                                  DISTRIBUTED BY (sid);';
+      EXECUTE 'UPDATE tmp_gpsid_count AS t SET base_id = (SELECT SUM(base_id) FROM tmp_gpsid_count AS t2 WHERE t2.sid <= t.sid);';
       RAISE NOTICE 'EXECUTING _fast_seqassign()...';
-      EXECUTE 'select * from _fast_seqassign(''' || quote_ident(tname) || ''', ''' || quote_ident(cname) || ''', ' || startid || ');';
+      EXECUTE 'SELECT * FROM _fast_seqassign(''' || QUOTE_IDENT(tname) || ''', ''' || QUOTE_IDENT(cname) || ''', ' || startid || ', ' || increment || ');';
       RETURN '';
     END;
     \$\$ LANGUAGE 'plpgsql';
 
-    CREATE OR REPLACE FUNCTION _fast_seqassign(tname character varying, cname character varying, startid bigint)
+    CREATE OR REPLACE FUNCTION _fast_seqassign(tname CHARACTER VARYING, cname CHARACTER VARYING, startid BIGINT, increment BIGINT)
     RETURNS TEXT AS
     \$\$
     DECLARE
-      sids int[] :=  ARRAY(SELECT sid FROM tmp_gpsid_count ORDER BY sid);
-      base_ids bigint[] :=  ARRAY(SELECT base_id FROM tmp_gpsid_count ORDER BY sid);
-      base_ids_noagg bigint[] :=  ARRAY(SELECT base_id FROM tmp_gpsid_count_noagg ORDER BY sid);
-      tsids text;
-      tbase_ids text;
-      tbase_ids_noagg text;
+      sids              INT[]    := ARRAY(SELECT sid     FROM tmp_gpsid_count       ORDER BY sid);
+      base_ids          BIGINT[] := ARRAY(SELECT base_id FROM tmp_gpsid_count       ORDER BY sid);
+      base_ids_noagg    BIGINT[] := ARRAY(SELECT base_id FROM tmp_gpsid_count_noagg ORDER BY sid);
+      tsids             TEXT;
+      tbase_ids         TEXT;
+      tbase_ids_noagg   TEXT;
     BEGIN
-      SELECT INTO tsids array_to_string(sids, ',');
-      SELECT INTO tbase_ids array_to_string(base_ids, ',');
-      SELECT INTO tbase_ids_noagg array_to_string(base_ids_noagg, ',');
-      if ('update ' || tname || ' set ' || cname || ' = updateid(' || startid || ', gp_segment_id, ARRAY[' || tsids || '], ARRAY[' || tbase_ids || '], ARRAY[' || tbase_ids_noagg || ']);')::text is not null then
-        EXECUTE 'update ' || tname || ' set ' || cname || ' = updateid(' || startid || ', gp_segment_id, ARRAY[' || tsids || '], ARRAY[' || tbase_ids || '], ARRAY[' || tbase_ids_noagg || ']);';
-      end if;
+      SELECT INTO tsids           ARRAY_TO_STRING(sids, ',');
+      SELECT INTO tbase_ids       ARRAY_TO_STRING(base_ids, ',');
+      SELECT INTO tbase_ids_noagg ARRAY_TO_STRING(base_ids_noagg, ',');
+      IF ('UPDATE ' || tname || ' SET ' || cname || ' = updateid(' || startid || ', ' || increment || ', gp_segment_id, ARRAY[' || tsids || '], ARRAY[' || tbase_ids || '], ARRAY[' || tbase_ids_noagg || ']);')::TEXT IS NOT NULL THEN
+        EXECUTE 'UPDATE ' || tname || ' SET ' || cname || ' = updateid(' || startid || ', ' || increment || ', gp_segment_id, ARRAY[' || tsids || '], ARRAY[' || tbase_ids || '], ARRAY[' || tbase_ids_noagg || ']);';
+      END IF;
       RETURN '';
     END;
     \$\$
     LANGUAGE 'plpgsql';
 
-    SELECT fast_seqassign('$Table', '$Column', $BeginId);
+    SELECT fast_seqassign('$Table', '$Column', $BeginId, $Increment);
 " && exit
 
 # Fall back to using PostgreSQL sequence generator named after the table and column
@@ -92,6 +93,7 @@ db-execute "
 seq="dd_seq_${Table}_${Column}"
 deepdive sql "
     DROP SEQUENCE IF EXISTS $seq CASCADE;
-    CREATE TEMPORARY SEQUENCE $seq MINVALUE -1 START $BeginId;
+    CREATE TEMPORARY SEQUENCE $seq INCREMENT BY $Increment MINVALUE $(($BeginId - 1)) START $BeginId;
+
     UPDATE $Table SET $Column = nextval('$seq');
 "

--- a/database/db-driver/greenplum/db-assign_sequential_id
+++ b/database/db-driver/greenplum/db-assign_sequential_id
@@ -57,12 +57,12 @@ db-execute "
       EXECUTE 'create table tmp_gpsid_count_noagg as select * from tmp_gpsid_count distributed by (sid);';
       EXECUTE 'update tmp_gpsid_count as t set base_id = (SELECT SUM(base_id) FROM tmp_gpsid_count as t2 WHERE t2.sid <= t.sid);';
       RAISE NOTICE 'EXECUTING _fast_seqassign()...';
-      EXECUTE 'select * from _fast_seqassign(''' || quote_ident(tname) || ''', ' || startid || ');';
+      EXECUTE 'select * from _fast_seqassign(''' || quote_ident(tname) || ''', ''' || quote_ident(cname) || ''', ' || startid || ');';
       RETURN '';
     END;
     \$\$ LANGUAGE 'plpgsql';
 
-    CREATE OR REPLACE FUNCTION _fast_seqassign(tname character varying, startid bigint)
+    CREATE OR REPLACE FUNCTION _fast_seqassign(tname character varying, cname character varying, startid bigint)
     RETURNS TEXT AS
     \$\$
     DECLARE

--- a/database/db-driver/greenplum/db-assign_sequential_id
+++ b/database/db-driver/greenplum/db-assign_sequential_id
@@ -92,9 +92,13 @@ else # if either plpgsql or plpythonu is not available
 # Fall back to using PostgreSQL sequence generator named after the table and column
 # See: http://www.postgresql.org/docs/current/static/sql-createsequence.html
 seq="dd_seq_${Table}_${Column}"
-deepdive sql "
+minMaxValues=
+if   [[ $Increment -gt 0 && $BeginId -le 0 ]]; then minMaxValues="MINVALUE $BeginId NO MAXVALUE"
+elif [[ $Increment -lt 0 && $BeginId -ge 0 ]]; then minMaxValues="NO MINVALUE MAXVALUE $BeginId"
+fi
+db-execute "
     DROP SEQUENCE IF EXISTS $seq CASCADE;
-    CREATE TEMPORARY SEQUENCE $seq INCREMENT BY $Increment MINVALUE $(($BeginId - 1)) START $BeginId;
+    CREATE TEMPORARY SEQUENCE $seq INCREMENT BY $Increment $minMaxValues START $BeginId NO CYCLE;
 
     UPDATE $Table SET $Column = nextval('$seq');
 "

--- a/database/db-driver/greenplum/db-assign_sequential_id
+++ b/database/db-driver/greenplum/db-assign_sequential_id
@@ -14,9 +14,8 @@ Table=$1 Column=$2 BeginId=$3 Increment=${4:-1}
 # See: http://www.postgresql.org/docs/8.2/static/sql-createlanguage.html
 # See: http://www.postgresql.org/docs/8.2/static/plpgsql-overview.html
 # See: http://www.postgresql.org/docs/8.2/static/plpython-funcs.html
-db-execute "CREATE LANGUAGE plpgsql;" || true
-db-execute "CREATE LANGUAGE plpythonu;" || true
-db-execute "
+if db-supports_pg_lang "plpgsql" && db-supports_pg_lang "plpythonu"; then
+    db-execute "
     CREATE OR REPLACE FUNCTION fast_seqassign_init()
     RETURNS INT AS \$\$
       if 'cumulative_cnt' in SD:
@@ -79,8 +78,9 @@ db-execute "
     \$\$ LANGUAGE 'plpgsql';
 
     SELECT fast_seqassign('$Table', '$Column', $BeginId, $Increment);
-" && exit
+"
 
+else # if either plpgsql or plpythonu is not available
 # Fall back to using PostgreSQL sequence generator named after the table and column
 # See: http://www.postgresql.org/docs/current/static/sql-createsequence.html
 seq="dd_seq_${Table}_${Column}"
@@ -90,3 +90,4 @@ deepdive sql "
 
     UPDATE $Table SET $Column = nextval('$seq');
 "
+fi

--- a/database/db-driver/greenplum/db-assign_sequential_id
+++ b/database/db-driver/greenplum/db-assign_sequential_id
@@ -18,29 +18,30 @@ if db-supports_pg_lang "plpgsql" && db-supports_pg_lang "plpythonu"; then
     db-execute "
     CREATE OR REPLACE FUNCTION fast_seqassign_init()
     RETURNS INT AS \$\$
-      if 'cumulative_cnt' in SD:
-        SD.pop('cumulative_cnt')
+      if 'cur_id' in SD:
+        SD.pop('cur_id')
       return 0
     \$\$ LANGUAGE plpythonu;
 
     CREATE OR REPLACE FUNCTION fast_seqassign_next(startid BIGINT, increment BIGINT, this_gpsid INT, gpsids INT[], cumulative_cnts BIGINT[], cnts BIGINT[])
     RETURNS BIGINT AS \$\$
-      if 'cumulative_cnt' not in SD:
+      if 'cur_id' not in SD:
         for gpsid, cumulative_cnt, cnt in zip(gpsids, cumulative_cnts, cnts):
           if gpsid == this_gpsid:
-            # assignment is done using the cumulative count for this segment and a decrementing counter from the size of this segment down to one
-            SD['cumulative_cnt'] = cumulative_cnt
-            SD['remaining'] = cnt
+            # find the id range using the cumulative count and the size of this segment
+            SD['cur_id'] = startid + increment * (cumulative_cnt - cnt)
+            SD['end_id'] = startid + increment *  cumulative_cnt
             break
-      if 'cumulative_cnt' in SD and SD['remaining'] > 0:
-        id = startid + increment * (SD['cumulative_cnt'] - SD['remaining'])
-        SD['remaining'] = SD['remaining'] - 1
-        if SD['remaining'] <= 0:
-          SD.pop('cumulative_cnt')
+        if 'cur_id' not in SD:
+          # XXX no segment was found
+          plpy.fatal('No non-empty id range was assigned for segment %s in the initial partition' % str(this_gpsid))
+      # generate fresh id as long as it's within the assigned range
+      id = SD['cur_id']
+      if id != SD['end_id']:
+        SD['cur_id'] += increment
         return id
       else:
-        # XXX no segment was found
-        raise plpy.ERROR('No non-empty id range was assigned for segment %s in the initial partition' % str(this_gpsid))
+        plpy.fatal('Insufficient id range was assigned for segment %s' % str(this_gpsid))
     \$\$ LANGUAGE plpythonu;
 
     CREATE OR REPLACE FUNCTION fast_seqassign(tname CHARACTER VARYING, cname CHARACTER VARYING, startid BIGINT, increment BIGINT)
@@ -61,9 +62,10 @@ if db-supports_pg_lang "plpgsql" && db-supports_pg_lang "plpythonu"; then
         gpsids          INT[]    := ARRAY(SELECT gpsid          FROM dd_tmp_id_ranges_by_gpsid ORDER BY gpsid);
         cumulative_cnts BIGINT[] := ARRAY(SELECT cumulative_cnt FROM dd_tmp_id_ranges_by_gpsid ORDER BY gpsid);
         cnts            BIGINT[] := ARRAY(SELECT cnt            FROM dd_tmp_id_ranges_by_gpsid ORDER BY gpsid);
+        update_query    TEXT;
       BEGIN
         EXECUTE 'SELECT fast_seqassign_init();';
-        EXECUTE 'UPDATE ' || tname || ' SET ' || cname || ' = fast_seqassign_next(
+        update_query := 'UPDATE ' || tname || ' SET ' || cname || ' = fast_seqassign_next(
             ' || startid || ',
             ' || increment || ',
             gp_segment_id,
@@ -71,6 +73,10 @@ if db-supports_pg_lang "plpgsql" && db-supports_pg_lang "plpythonu"; then
             ARRAY[' || ARRAY_TO_STRING(cumulative_cnts, ',')::TEXT || '],
             ARRAY[' || ARRAY_TO_STRING(           cnts, ',')::TEXT || ']
           );';
+        IF update_query::TEXT IS NOT NULL THEN
+          -- update_query IS NULL for empty tables, hence this guard is necessary
+          EXECUTE update_query;
+        END IF;
         RETURN 'fast_seqassign done for segments [' || ARRAY_TO_STRING(gpsids, ',') || ']' ||
                ' with counts [' || ARRAY_TO_STRING(cnts, ',') || ']';
       END;

--- a/database/db-driver/greenplum/db-supports_pg_lang
+++ b/database/db-driver/greenplum/db-supports_pg_lang
@@ -1,0 +1,1 @@
+../postgresql/db-supports_pg_lang

--- a/database/db-driver/mysql/db-assign_sequential_id
+++ b/database/db-driver/mysql/db-assign_sequential_id
@@ -10,6 +10,8 @@ set -euo pipefail
 [[ $# -gt 2 ]] || usage "$0" "Missing BEGIN_ID"
 Table=$1 Column=$2 BeginId=$3 Increment=${4:-1}
 
+[[ $Increment -ne 0 ]] || usage "$0" "INCREMENT must be non-zero"
+
 # Use user-defined variable to assign sequential integers
 # See: http://dev.mysql.com/doc/refman/5.0/en/user-variables.html
 db-execute "

--- a/database/db-driver/mysql/db-assign_sequential_id
+++ b/database/db-driver/mysql/db-assign_sequential_id
@@ -13,6 +13,6 @@ Table=$1 Column=$2 BeginId=$3 Increment=${4:-1}
 # Use user-defined variable to assign sequential integers
 # See: http://dev.mysql.com/doc/refman/5.0/en/user-variables.html
 db-execute "
-    SET @id = $BeginId - 1;
+    SET @id = $BeginId - $Increment;
     UPDATE $Table SET $Column = @id := @id + $Increment;
 "

--- a/database/db-driver/postgresql-xl/db-assign_sequential_id
+++ b/database/db-driver/postgresql-xl/db-assign_sequential_id
@@ -10,6 +10,8 @@ set -euo pipefail
 [[ $# -gt 2 ]] || usage "$0" "Missing BEGIN_ID"
 Table=$1 Column=$2 BeginId=$3 Increment=${4:-1}
 
+[[ $Increment -ne 0 ]] || usage "$0" "INCREMENT must be non-zero"
+
 # Use a PostgreSQL-XL PL/pgSQL UDF to assign IDs fast
 # See: http://www.postgresql.org/docs/9.2/static/sql-createlanguage.html
 # See: http://www.postgresql.org/docs/9.2/static/plpgsql.html

--- a/database/db-driver/postgresql-xl/db-assign_sequential_id
+++ b/database/db-driver/postgresql-xl/db-assign_sequential_id
@@ -13,7 +13,7 @@ Table=$1 Column=$2 BeginId=$3 Increment=${4:-1}
 # Use a PostgreSQL-XL PL/pgSQL UDF to assign IDs fast
 # See: http://www.postgresql.org/docs/9.2/static/sql-createlanguage.html
 # See: http://www.postgresql.org/docs/9.2/static/plpgsql.html
-db-execute "CREATE LANGUAGE plpgsql;" || true
+db-supports_pg_lang "plpgsql" &&
 db-execute "
     CREATE OR REPLACE FUNCTION copy_table_assign_ids_replace(
       schema_name character varying,

--- a/database/db-driver/postgresql-xl/db-supports_pg_lang
+++ b/database/db-driver/postgresql-xl/db-supports_pg_lang
@@ -1,0 +1,1 @@
+../postgresql/db-supports_pg_lang

--- a/database/db-driver/postgresql/db-assign_sequential_id
+++ b/database/db-driver/postgresql/db-assign_sequential_id
@@ -10,6 +10,8 @@ set -euo pipefail
 [[ $# -gt 2 ]] || usage "$0" "Missing BEGIN_ID"
 Table=$1 Column=$2 BeginId=$3 Increment=${4:-1}
 
+[[ $Increment -ne 0 ]] || usage "$0" "INCREMENT must be non-zero"
+
 # Use PostgreSQL sequence generator named after the table and column
 # See: http://www.postgresql.org/docs/current/static/sql-createsequence.html
 seq="dd_seq_${Table}_${Column}"

--- a/database/db-driver/postgresql/db-assign_sequential_id
+++ b/database/db-driver/postgresql/db-assign_sequential_id
@@ -16,7 +16,7 @@ seq="dd_seq_${Table}_${Column}"
 
 db-execute "
     DROP SEQUENCE IF EXISTS $seq CASCADE;
-    CREATE TEMPORARY SEQUENCE $seq INCREMENT BY $Increment MINVALUE -1 START $BeginId;
+    CREATE TEMPORARY SEQUENCE $seq INCREMENT BY $Increment MINVALUE $(($BeginId - 1)) START $BeginId;
 
     UPDATE $Table SET $Column = nextval('$seq');
 "

--- a/database/db-driver/postgresql/db-assign_sequential_id
+++ b/database/db-driver/postgresql/db-assign_sequential_id
@@ -15,10 +15,13 @@ Table=$1 Column=$2 BeginId=$3 Increment=${4:-1}
 # Use PostgreSQL sequence generator named after the table and column
 # See: http://www.postgresql.org/docs/current/static/sql-createsequence.html
 seq="dd_seq_${Table}_${Column}"
-
+minMaxValues=
+if   [[ $Increment -gt 0 && $BeginId -le 0 ]]; then minMaxValues="MINVALUE $BeginId NO MAXVALUE"
+elif [[ $Increment -lt 0 && $BeginId -ge 0 ]]; then minMaxValues="NO MINVALUE MAXVALUE $BeginId"
+fi
 db-execute "
     DROP SEQUENCE IF EXISTS $seq CASCADE;
-    CREATE TEMPORARY SEQUENCE $seq INCREMENT BY $Increment MINVALUE $(($BeginId - 1)) START $BeginId;
+    CREATE TEMPORARY SEQUENCE $seq INCREMENT BY $Increment $minMaxValues START $BeginId NO CYCLE;
 
     UPDATE $Table SET $Column = nextval('$seq');
 "

--- a/database/db-driver/postgresql/db-supports_pg_lang
+++ b/database/db-driver/postgresql/db-supports_pg_lang
@@ -7,5 +7,5 @@ set -euo pipefail
 
 Lang=$1; shift
 
-[[ $(db-query "SELECT COUNT(*) FROM pg_catalog.pg_language WHERE lanname = '$Lang'") -gt 1 ]] ||
+[[ $(db-query "SELECT COUNT(*) FROM pg_catalog.pg_language WHERE lanname = '$Lang'" tsv 0) -gt 0 ]] ||
     db-execute "CREATE LANGUAGE $Lang"

--- a/database/db-driver/postgresql/db-supports_pg_lang
+++ b/database/db-driver/postgresql/db-supports_pg_lang
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# db-supports_pg_lang -- Creates a PostgreSQL language if it doesn't exist yet
+# > eval "$(db-parse "$url")"
+# > db-supports_pg_lang LANG
+##
+set -euo pipefail
+
+Lang=$1; shift
+
+[[ $(db-query "SELECT COUNT(*) FROM pg_catalog.pg_language WHERE lanname = '$Lang'") -gt 1 ]] ||
+    db-execute "CREATE LANGUAGE $Lang"

--- a/test/greenplum/chunking_example
+++ b/test/greenplum/chunking_example
@@ -1,0 +1,1 @@
+../../examples/chunking

--- a/test/greenplum/db-assign_sequential_id.bats
+++ b/test/greenplum/db-assign_sequential_id.bats
@@ -1,0 +1,1 @@
+../postgresql/db-assign_sequential_id.bats

--- a/test/greenplum/should-work.sh
+++ b/test/greenplum/should-work.sh
@@ -8,5 +8,5 @@ cd "$(dirname "$0")"
     # gpfdist should be on PATH to say Greenplum is there
     type gpfdist
     # also check database version
-    [[ "$(DBNAME=postgres db-execute "COPY (SELECT VERSION() LIKE '%Greenplum%') TO STDOUT")" == t ]]  # TODO move this check to db-init?
+    [[ "$(DBNAME=postgres timeout 1s db-execute "COPY (SELECT VERSION() LIKE '%Greenplum%') TO STDOUT")" == t ]]  # TODO move this check to db-init?
 } &>/dev/null

--- a/test/mysql/db-assign_sequential_id.bats
+++ b/test/mysql/db-assign_sequential_id.bats
@@ -1,0 +1,1 @@
+../postgresql/db-assign_sequential_id.bats

--- a/test/mysql/should-work.sh
+++ b/test/mysql/should-work.sh
@@ -6,5 +6,5 @@ cd "$(dirname "$0")"
 . ./env.sh
 {
     # try executing a SQL query against the configured database for tests
-    DBNAME=mysql db-execute "SELECT VERSION()"
+    DBNAME=mysql timeout 1s db-execute "SELECT VERSION()"
 } &>/dev/null

--- a/test/postgresql-xl/db-assign_sequential_id.bats
+++ b/test/postgresql-xl/db-assign_sequential_id.bats
@@ -1,0 +1,1 @@
+../postgresql/db-assign_sequential_id.bats

--- a/test/postgresql-xl/should-work.sh
+++ b/test/postgresql-xl/should-work.sh
@@ -6,5 +6,5 @@ cd "$(dirname "$0")"
 . ./env.sh
 {
     # check database version
-    [[ "$(DBNAME=postgres db-execute "COPY (SELECT VERSION() LIKE '%Postgres-XL%') TO STDOUT")" == t ]]  # TODO move this check to db-init?
+    [[ "$(DBNAME=postgres timeout 1s db-execute "COPY (SELECT VERSION() LIKE '%Postgres-XL%') TO STDOUT")" == t ]]  # TODO move this check to db-init?
 } &>/dev/null

--- a/test/postgresql/db-assign_sequential_id.bats
+++ b/test/postgresql/db-assign_sequential_id.bats
@@ -3,20 +3,34 @@
 
 . "$BATS_TEST_DIRNAME"/env.sh >&2
 
+setup() {
+    db-execute "SELECT 1" &>/dev/null || db-init
+}
+
+@test "$DBVARIANT db-assign_sequential_id usage" {
+    # make sure it fails on inssuficient arguments
+    ! deepdive db assign_sequential_id              || false
+    ! deepdive db assign_sequential_id table        || false
+    ! deepdive db assign_sequential_id table column || false
+}
+
 @test "$DBVARIANT db-assign_sequential_id works" {
-    numrows=1000
+    for numrows in 0 1 1000; do
+        # set up a table
+        echo "Setting up a table of $numrows rows"
+        deepdive sql "DROP TABLE foo CASCADE;" || true
+        deepdive sql "CREATE TABLE foo(x TEXT, y BIGINT);"
+        seq $numrows | sed 's/.*/INSERT INTO foo(x) VALUES (&);/' | deepdive sql
 
-    # set up a table
-    deepdive sql "DROP TABLE foo CASCADE;" || true
-    deepdive sql "CREATE TABLE foo(x TEXT, y BIGINT);"
-    seq $numrows | sed 's/.*/INSERT INTO foo(x) VALUES (&);/' | deepdive sql
-
-    for increment in 1234 37 23 10 1; do
-        for begin in 12345 -678 1 0; do
-            end=$(($begin + ($numrows - 1) * $increment))
-            echo "Testing assign_sequential_id from $begin to $end by increment $increment ($numrows rows)"
-            deepdive db assign_sequential_id foo y $begin $increment
-            diff -u <(seq $begin $increment $end) <(deepdive sql eval "SELECT y FROM foo ORDER BY y")
+        for increment in 123 10 1; do
+            for begin in 12345 -678 1 0; do
+                end=$(($begin + ($numrows - 1) * $increment))
+                echo "Testing assign_sequential_id from $begin to $end by increment $increment ($numrows rows)"
+                # assign sequence
+                deepdive db assign_sequential_id foo y $begin $increment
+                # and compare with what's expected
+                diff -u <(seq $begin $increment $end) <(deepdive sql eval "SELECT y FROM foo ORDER BY y")
+            done
         done
     done
 }

--- a/test/postgresql/db-assign_sequential_id.bats
+++ b/test/postgresql/db-assign_sequential_id.bats
@@ -15,6 +15,7 @@ setup() {
 }
 
 @test "$DBVARIANT db-assign_sequential_id works" {
+    num_failures=0
     for numrows in 0 1 1000; do
         # set up a table
         echo "Setting up a table of $numrows rows"
@@ -27,10 +28,14 @@ setup() {
                 end=$(($begin + ($numrows - 1) * $increment))
                 echo "Testing assign_sequential_id from $begin to $end by increment $increment ($numrows rows)"
                 # assign sequence
-                deepdive db assign_sequential_id foo y $begin $increment
+                deepdive db assign_sequential_id foo y $begin $increment || let ++num_failures
                 # and compare with what's expected
-                diff -u <(seq $begin $increment $end) <(deepdive sql eval "SELECT y FROM foo ORDER BY y")
+                diff -u <(seq $begin $increment $end) <(deepdive sql eval "SELECT y FROM foo ORDER BY y") || let ++num_failures
             done
         done
     done
+    [[ $num_failures -eq 0 ]] || {
+        echo "Failed $num_failures checks"
+        false
+    }
 }

--- a/test/postgresql/db-assign_sequential_id.bats
+++ b/test/postgresql/db-assign_sequential_id.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+# Tests for biased coin example
+
+. "$BATS_TEST_DIRNAME"/env.sh >&2
+
+@test "$DBVARIANT db-assign_sequential_id works" {
+    numrows=1000
+
+    # set up a table
+    deepdive sql "DROP TABLE foo CASCADE;" || true
+    deepdive sql "CREATE TABLE foo(x TEXT, y BIGINT);"
+    seq $numrows | sed 's/.*/INSERT INTO foo(x) VALUES (&);/' | deepdive sql
+
+    for increment in 1234 37 23 10 1; do
+        for begin in 12345 -678 1 0; do
+            end=$(($begin + ($numrows - 1) * $increment))
+            echo "Testing assign_sequential_id from $begin to $end by increment $increment ($numrows rows)"
+            deepdive db assign_sequential_id foo y $begin $increment
+            diff -u <(seq $begin $increment $end) <(deepdive sql eval "SELECT y FROM foo ORDER BY y")
+        done
+    done
+}

--- a/test/postgresql/db-assign_sequential_id.bats
+++ b/test/postgresql/db-assign_sequential_id.bats
@@ -33,6 +33,9 @@ setup() {
                 diff -u <(seq $begin $increment $end) <(deepdive sql eval "SELECT y FROM foo ORDER BY y") || let ++num_failures
             done
         done
+
+        echo "Testing if zero increment is rejected"
+        ! deepdive db assign_sequential_id foo y $begin 0 || let ++num_failures
     done
     [[ $num_failures -eq 0 ]] || {
         echo "Failed $num_failures checks"

--- a/test/postgresql/should-work.sh
+++ b/test/postgresql/should-work.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"
 . ./env.sh
 {
     # try executing a SQL query against the configured database for tests
-    [[ "$(DBNAME=postgres db-execute "COPY (SELECT VERSION() LIKE '%PostgreSQL%'
+    [[ "$(DBNAME=postgres timeout 1s db-execute "COPY (SELECT VERSION() LIKE '%PostgreSQL%'
         AND NOT ( VERSION() LIKE '%Postgres-XL%'
              OR   VERSION() LIKE '%Greenplum%'
         )) TO STDOUT")" == t ]]


### PR DESCRIPTION
Fixes #495 as well as related bugs and adds tests.

Does anyone have some numbers comparing SEQUENCE vs. this Python UDF? @zhangce @feiranwang @SenWu  Is GP SEQUENCE that slow?  I remember in PGXL's case, SEQUENCE was completely broken (all data nodes were assigning duplicates), but if GP managed to support it, I think it's better to rely on it.