### PR TITLE
Adds ddlib support for python2 and python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 /examples/tutorial_example/*/experiment-reports/latest
 /examples/spouse_example/data/sentences_dump_large.csv
 /examples/spouse_example/data/spouses.tsv
+
+# python-related
+*.pyc
+__pycache__/

--- a/ddlib/Makefile
+++ b/ddlib/Makefile
@@ -1,6 +1,18 @@
 do:
-	cat test.json | python ./without_ddlib.py > a
-	cat test.json | python ./with_ddlib.py > b
+	cat test.json | python without_ddlib.py > a
+	cat test.json | python with_ddlib.py > b
+	diff a b
+	rm a
+	rm b
+py3:
+	cat test.json | python3 without_ddlib.py > a
+	cat test.json | python3 with_ddlib.py > b
+	diff a b
+	rm a
+	rm b
+py2py3:
+	cat test.json | python with_ddlib.py > a
+	cat test.json | python3 with_ddlib.py > b
 	diff a b
 	rm a
 	rm b

--- a/ddlib/ddlib/__init__.py
+++ b/ddlib/ddlib/__init__.py
@@ -1,3 +1,3 @@
-from dd import *
-from gen_feats import *
-from util import *
+from .dd import *
+from .gen_feats import *
+from .util import *

--- a/ddlib/ddlib/gen_feats.py
+++ b/ddlib/ddlib/gen_feats.py
@@ -10,7 +10,7 @@
 # Matteo, December 2014
 #
 
-from dd import dep_path_between_words, materialize_span, Span, unpack_words
+from .dd import dep_path_between_words, materialize_span, Span, unpack_words
 
 MAX_KW_LENGTH = 3
 

--- a/ddlib/ddlib/util.py
+++ b/ddlib/ddlib/util.py
@@ -3,7 +3,7 @@ import re
 import sys
 from inspect import isgeneratorfunction,getargspec
 import csv
-from StringIO import StringIO
+from io import StringIO
 
 def print_error(err_string):
   """Function to write to stderr"""
@@ -113,7 +113,7 @@ def print_pgtsv_element(x, n, t, d=0):
   # Handle NULLs first
   if x is None:
     if d == 0:
-      return '\N'
+      return r'\N'
     else:
       return ''
 
@@ -153,7 +153,7 @@ class PGTSVPrinter:
         num_rows_declared=len(self.fields), num_rows_found=len(out), row=out,
       ))
     else:
-      print '\t'.join(print_pgtsv_element(x, n, t) for x,(n,t) in zip(out, self.fields))
+      print('\t'.join(print_pgtsv_element(x, n, t) for x,(n,t) in zip(out, self.fields)))
 
 
 # how to get types specified as default values of a function

--- a/ddlib/deepdive.py
+++ b/ddlib/deepdive.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
 # a facade package to expose some useful things
+
+from __future__ import absolute_import, print_function, unicode_literals
 from ddlib.util import tsv_extractor,over,returns
 from collections import OrderedDict

--- a/ddlib/test.py
+++ b/ddlib/test.py
@@ -12,17 +12,17 @@ class TestDDLib(unittest.TestCase):
   def test_materialize_span(self):
     span1 = dd.Span(0, 3)
     materialized_span = dd.materialize_span(self.words, span1)
-    self.assertEqual(materialized_span[:], ["Tanja", "married", "Jake"])
+    self.assertEqual(list(materialized_span), ["Tanja", "married", "Jake"])
 
   def test_tokens_between_spans(self):
     span1 = dd.Span(0, 2)
     span2 = dd.Span(3, 5)
     words_between = dd.tokens_between_spans(self.words, span1, span2)
-    self.assertEqual(words_between[:], (False, ["Jake"]))
+    self.assertEqual([words_between[0], list(words_between[1])], [False, ["Jake"]])
     words_between = dd.tokens_between_spans(self.words, span2, span1)
-    self.assertEqual(words_between[:], (True, ["Jake"]))
+    self.assertEqual([words_between[0], list(words_between[1])], [True, ["Jake"]])
     words_between = dd.tokens_between_spans(self.words, span1, span1)
-    self.assertEqual(words_between[:], (False, []))
+    self.assertEqual([words_between[0], list(words_between[1])], [False, []])
 
 
 if __name__ == '__main__':

--- a/ddlib/with_ddlib.py
+++ b/ddlib/with_ddlib.py
@@ -31,13 +31,13 @@ for row in sys.stdin:
   # Intuition: if they are close by, the link may be stronger.
   #
   words_between = ddlib.tokens_between_spans(words, span1, span2)
-  l = len(words_between.elements)
+  l = len(list(words_between.elements))
   features.add("num_words_between=%s" % l if l<5 else "many_words_between")
 
   # Feature 3: Check if the last name matches heuristically.
   #
-  last_word_left = ddlib.materialize_span(words, span1)[-1]
-  last_word_right = ddlib.materialize_span(words, span2)[-1]
+  last_word_left = list(ddlib.materialize_span(words, span1))[-1]
+  last_word_right = list(ddlib.materialize_span(words, span2))[-1]
   if (last_word_left == last_word_right):
     features.add("potential_last_name_match")
 
@@ -45,9 +45,9 @@ for row in sys.stdin:
   #
   #ddlib.log(features)
 
-  for feature in features:
-    print json.dumps({
+  for feature in sorted(features):
+    print(json.dumps({
       "relation_id": obj["relation_id"],
       "feature": feature
-    })
+    }, sort_keys=True))
 

--- a/ddlib/without_ddlib.py
+++ b/ddlib/without_ddlib.py
@@ -48,8 +48,8 @@ for row in sys.stdin:
     features.add("potential_last_name_match")
 
   # TODO: Add more features, look at dependency paths, etc
-  for feature in features:
-    print json.dumps({
+  for feature in sorted(features):
+    print(json.dumps({
       "relation_id": obj["relation_id"],
       "feature": feature
-    })
+    }, sort_keys=True))


### PR DESCRIPTION
* Changes print statements to functions
* Changes relative imports to be explicit (PEP 328)
* Adds \N unicode character escape (raw string)
* Adds makefile tests to be consistent with previous output tests
* Adds some sorts to output methods to make output deterministic -- sorts values
for the features set and in the json.dumps() output to ensure that output is the
same between runs with the same input data (and for the makefile tests)
* Adds new tests within the included Makefile to compare Python3 +/- ddlib
output and Python2/ddlib vs. Python3/ddlib output
* Fixes unit tests in test.py to iterate through generators when necessary

```python
ip-172-30-0-123 python> deepdive env python
Python 2.7.6 (default, Jun 22 2015, 17:58:13) 
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from deepdive import *
>>> from ddlib import *
>>> tsv_extractor
<function tsv_extractor at 0x7f0dd2db0c80>
>>> 
ip-172-30-0-123 python> deepdive env python3
Python 3.4.3 (default, Oct 14 2015, 20:28:29) 
[GCC 4.8.4] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from deepdive import *
>>> from ddlib import *
>>> tsv_extractor
<function tsv_extractor at 0x7f512f97ae18>
>>> 
```