### PR TITLE
Add timestamp conversion from Postgres dump to JSON

### DIFF
--- a/database/pgtsv_to_json
+++ b/database/pgtsv_to_json
@@ -7,17 +7,19 @@ from datetime import datetime
 
 def timestamp(timestamp_str):
     """Given a timestamp string, return a timestamp string in ISO 8601 format to emulate
-    Postgres 9.5's to_json timestamp formatting. The given timestamp is assumed UTC.
+    Postgres 9.5's to_json timestamp formatting.
 
-    Time zones are not supported. http://bugs.python.org/issue6641
+    This supports the `timestamp without time zone` PostgreSQL type.
+
+    Time zone offsets are not supported. http://bugs.python.org/issue6641
 
     Examples:
 
         >>> timestamp('2016-06-17 20:10:38')
-        '2016-06-17T20:10:38+00:00'
+        '2016-06-17T20:10:38'
 
         >>> timestamp('2016-06-17 20:10:37.9293')
-        '2016-06-17T20:10:37.929300+00:00'
+        '2016-06-17T20:10:37.929300'
 
     """
 
@@ -25,7 +27,7 @@ def timestamp(timestamp_str):
         parsed = datetime.strptime(timestamp_str, '%Y-%m-%d %H:%M:%S.%f')
     except ValueError:
         parsed = datetime.strptime(timestamp_str, '%Y-%m-%d %H:%M:%S')
-    return parsed.isoformat() + '+00:00'
+    return parsed.isoformat()
 
 # given a column type, returns a function that takes a string input
 # and output with the correct type
@@ -48,7 +50,7 @@ def convert_type_func(ty, ty_rest = ""):
       return convert_other_array
   else: # non-array, must be primitive type
     normalized_type_name = {
-        "timestamp": "timestamp",
+        "timestamp without time zone": "timestamp",
         "integer" : "int",
         "bigint"  : "int",
         "double"  : "float",
@@ -64,8 +66,8 @@ def convert_type_func(ty, ty_rest = ""):
         }
     # find the convert function with normalized type name
     ty = ty.lower()
-    if ty.startswith('timestamp'):
-      ty = 'timestamp'
+    if re.match('timestamp(\(\d\))? without time zone', ty):
+      ty = 'timestamp without time zone'
     if ty in normalized_type_name:
       ty = normalized_type_name[ty]
     if ty in convert_for_primitive_types:

--- a/database/pgtsv_to_json
+++ b/database/pgtsv_to_json
@@ -3,6 +3,29 @@
 # Usage: pgtsv_to_json COLUMN_NAME1:TYPE1 COLUMN_NAME2:TYPE2 ...
 
 import json, sys, csv, re
+from datetime import datetime
+
+def timestamp(timestamp_str):
+    """Given a timestamp string, return a timestamp string in ISO 8601 format to emulate
+    Postgres 9.5's to_json timestamp formatting. The given timestamp is assumed UTC.
+
+    Time zones are not supported. http://bugs.python.org/issue6641
+
+    Examples:
+
+        >>> timestamp('2016-06-17 20:10:38')
+        '2016-06-17T20:10:38+00:00'
+
+        >>> timestamp('2016-06-17 20:10:37.9293')
+        '2016-06-17T20:10:37.929300+00:00'
+
+    """
+
+    try:
+        parsed = datetime.strptime(timestamp_str, '%Y-%m-%d %H:%M:%S.%f')
+    except ValueError:
+        parsed = datetime.strptime(timestamp_str, '%Y-%m-%d %H:%M:%S')
+    return parsed.isoformat() + '+00:00'
 
 # given a column type, returns a function that takes a string input
 # and output with the correct type
@@ -25,6 +48,7 @@ def convert_type_func(ty, ty_rest = ""):
       return convert_other_array
   else: # non-array, must be primitive type
     normalized_type_name = {
+        "timestamp": "timestamp",
         "integer" : "int",
         "bigint"  : "int",
         "double"  : "float",
@@ -32,6 +56,7 @@ def convert_type_func(ty, ty_rest = ""):
         "unknown" : "text",
         }
     convert_for_primitive_types = {
+        "timestamp": timestamp,
         "int"     : int,
         "float"   : float,
         "text"    : lambda x: x,
@@ -39,6 +64,8 @@ def convert_type_func(ty, ty_rest = ""):
         }
     # find the convert function with normalized type name
     ty = ty.lower()
+    if ty.startswith('timestamp'):
+      ty = 'timestamp'
     if ty in normalized_type_name:
       ty = normalized_type_name[ty]
     if ty in convert_for_primitive_types:

--- a/database/pgtsv_to_json
+++ b/database/pgtsv_to_json
@@ -27,6 +27,8 @@ def timestamp(timestamp_str):
         parsed = datetime.strptime(timestamp_str, '%Y-%m-%d %H:%M:%S.%f')
     except ValueError:
         parsed = datetime.strptime(timestamp_str, '%Y-%m-%d %H:%M:%S')
+    except ValueError:
+        return timestamp_str
     return parsed.isoformat()
 
 # given a column type, returns a function that takes a string input


### PR DESCRIPTION
The `pgtsv_to_json` module is the fallback for database systems that don't support `to_json()`. It's called when I run on Greenplum, but I have timestamps in my table. Without this commit, the module terminates on a ValueError. With this commit, timestamp input columns are included in the JSON output.