### PR TITLE
Var values are int with refactored sampler

### DIFF
--- a/compiler/compile-config/compile-config-1.01-parse_inference_rules
+++ b/compiler/compile-config/compile-config-1.01-parse_inference_rules
@@ -26,7 +26,7 @@ include "util";
             , params: (ltrimstr("?") | trimWhitespace
                 | ltrimstr("(") | rtrimstr(")") | trimWhitespace
                 | if length == 0 then [] else split("\\s*,\\s*"; "") end)
-            , init_value: 0.0
+            , init_value: 0
             }
         else
             # fixed weight

--- a/compiler/compile-config/compile-config-2.01-grounding
+++ b/compiler/compile-config/compile-config-2.01-grounding
@@ -236,11 +236,11 @@ def factorWeightDescriptionSqlExpr:
                 , { alias: "init_value", expr:
                     "CASE WHEN variable_role = 0 THEN 0
                           ELSE (\(
-                            if   .variableType == "boolean"     then "CASE WHEN label THEN 1 ELSE 0 END" # XXX a portable way to turn boolean to integers in SQL, CAST(label AS INT) does not work for MySQL
+                            if   .variableType == "boolean"     then "CASE WHEN label THEN 1 ELSE 0 END"
                             elif .variableType == "categorical" then "label"
                             else error("Internal error: Unknown variableType: \(.variableType)")
                             end
-                            )) + 0.0
+                            ))
                       END" }
                 , { column: "variable_type" }
                 , { column: "cardinality" }


### PR DESCRIPTION
With https://github.com/HazyResearch/sampler/pull/30 , sampler now expects variable init_values to be INT (instead of DOUBLE).