### PR TITLE
Add dependency for perl-Time-HiRes

### DIFF
--- a/util/install/install.RedHat.sh
+++ b/util/install/install.RedHat.sh
@@ -59,6 +59,7 @@ install__deepdive_runtime_deps() {
         java
         gnuplot
         libtool-ltdl # for graphviz
+        perl-Time-HiRes
     )
     sudo yum install -y "${runtime_deps[@]}"
     sudo localedef -f UTF-8 -i en_US en_US.UTF-8


### PR DESCRIPTION
Following error is raised when running deepdive run_deepdive_tests

    `DEEPDIVE_COMPILE_INPUT_JSON= deepdive compile || false' failed
       Can't locate Time/HiRes.pm in @INC (you may need to install the Time::HiRes module) (@INC contains: /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .)