### PR TITLE
FG sharding: process a 100TB FG on one box or many

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
   # Pull Docker images
   - docker pull $DOCKER_IMAGE_MASTER;
-  - docker pull infiniteblue/postgres:9.5.0;  # we need plpython for ID assignment
+  - docker pull postgres:9.5;  # we need plpython for ID assignment
 
 install:
   # Build using Docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
   # Pull Docker images
   - docker pull $DOCKER_IMAGE_MASTER;
-  - docker pull infiniteblue/postgres:9.5;  # we need plpython for ID assignment
+  - docker pull infiniteblue/postgres:9.5.0;  # we need plpython for ID assignment
 
 install:
   # Build using Docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
   # Pull Docker images
   - docker pull $DOCKER_IMAGE_MASTER;
-  - docker pull postgres;
+  - docker pull infiniteblue/postgres:9.5;  # we need plpython for ID assignment
 
 install:
   # Build using Docker

--- a/DockerBuild/Dockerfile.postgres
+++ b/DockerBuild/Dockerfile.postgres
@@ -1,0 +1,6 @@
+FROM postgres:9.5
+
+RUN apt-get update \
+  && apt-get install -y postgresql-server-dev-${PG_MAJOR} postgresql-plpython-${PG_MAJOR}
+
+RUN echo 'PGPASSWORD="$POSTGRES_PASSWORD" psql -U $POSTGRES_USER template1 -c "CREATE EXTENSION plpythonu;"' > /docker-entrypoint-initdb.d/plpythonu.sh

--- a/DockerBuild/test-in-container-postgres
+++ b/DockerBuild/test-in-container-postgres
@@ -17,7 +17,7 @@ set -x
 docker run --detach --name "$DOCKER_PGNAME" \
     --env POSTGRES_USER="$USER" \
     --env POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
-    infiniteblue/postgres:9.5 \
+    infiniteblue/postgres:9.5.0 \
     #
 
 # wait until postgres starts

--- a/DockerBuild/test-in-container-postgres
+++ b/DockerBuild/test-in-container-postgres
@@ -11,13 +11,14 @@ set -euo pipefail
 : ${POSTGRES_START_TIME:=4} # seconds
 
 # run a postgres container
-# we need plpython for ID assignment, hence infiniteblue/postgres, not _/postgres
+# we need plpython for ID assignment, hence Dockerfile.postgres
 trap 'docker rm -f "$DOCKER_PGNAME"' EXIT
 set -x
+docker build -t pgsql -f "$(dirname "$0")"/Dockerfile.postgres .
 docker run --detach --name "$DOCKER_PGNAME" \
     --env POSTGRES_USER="$USER" \
     --env POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
-    infiniteblue/postgres:9.5.0 \
+    pgsql \
     #
 
 # wait until postgres starts
@@ -25,7 +26,7 @@ postgres-has-started() {
     docker run --rm --name "$DOCKER_PGNAME.check" \
         --link "$DOCKER_PGNAME" \
         --env PGPASSWORD="$POSTGRES_PASSWORD" \
-        infiniteblue/postgres:9.5.0 \
+        pgsql \
         psql -h "$DOCKER_PGNAME" -U "$USER" -l
 }
 sleep $POSTGRES_START_TIME  # give it some initial time to start

--- a/DockerBuild/test-in-container-postgres
+++ b/DockerBuild/test-in-container-postgres
@@ -11,12 +11,13 @@ set -euo pipefail
 : ${POSTGRES_START_TIME:=4} # seconds
 
 # run a postgres container
+# we need plpython for ID assignment, hence infiniteblue/postgres, not _/postgres
 trap 'docker rm -f "$DOCKER_PGNAME"' EXIT
 set -x
 docker run --detach --name "$DOCKER_PGNAME" \
     --env POSTGRES_USER="$USER" \
     --env POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
-    postgres \
+    infiniteblue/postgres:9.5 \
     #
 
 # wait until postgres starts
@@ -24,7 +25,7 @@ postgres-has-started() {
     docker run --rm --name "$DOCKER_PGNAME.check" \
         --link "$DOCKER_PGNAME" \
         --env PGPASSWORD="$POSTGRES_PASSWORD" \
-        postgres \
+        infiniteblue/postgres:9.5 \
         psql -h "$DOCKER_PGNAME" -U "$USER" -l
 }
 sleep $POSTGRES_START_TIME  # give it some initial time to start

--- a/DockerBuild/test-in-container-postgres
+++ b/DockerBuild/test-in-container-postgres
@@ -25,7 +25,7 @@ postgres-has-started() {
     docker run --rm --name "$DOCKER_PGNAME.check" \
         --link "$DOCKER_PGNAME" \
         --env PGPASSWORD="$POSTGRES_PASSWORD" \
-        infiniteblue/postgres:9.5 \
+        infiniteblue/postgres:9.5.0 \
         psql -h "$DOCKER_PGNAME" -U "$USER" -l
 }
 sleep $POSTGRES_START_TIME  # give it some initial time to start

--- a/compiler/compile-config/compile-config-0.01-parse_schema
+++ b/compiler/compile-config/compile-config-0.01-parse_schema
@@ -27,6 +27,10 @@ include "util";
             end
             | .[].key
             ]
+        , variablesParitionColumns  : [ [ $deepdive.schema.relations[$relationName].columns | to_entries[]? ]
+            | [.[] | select([.value.annotations[]? | .name == "partition"] | any)]
+            | .[].key
+            ]
         , variableType : ($variableType | trimWhitespace | ascii_downcase
             | if in({boolean: 1, categorical: 1}) then .
             else error("deepdive.schema.variables.\($relationName).\($columnName) has an unrecognized type: \($variableType | @json)")

--- a/compiler/compile-config/compile-config-2.01-grounding
+++ b/compiler/compile-config/compile-config-2.01-grounding
@@ -16,7 +16,7 @@ def factorWeightDescriptionSqlExpr:
     [ ("\(.factorName)-" | asSqlLiteral)
     , (.weight_.params[] |
         "CASE WHEN \(asSqlIdent) IS NULL THEN ''
-              ELSE \(asSqlIdent) || ''  -- XXX CAST(... AS TEXT) unsupported by MySQL
+              ELSE CAST(\(asSqlIdent) AS TEXT)
           END"
       )
     ] | join(" ||\("-" | asSqlLiteral)|| ")
@@ -36,10 +36,6 @@ def factorWeightDescriptionSqlExpr:
             "data/\(.variablesTable)"
         ],
         style: "cmd_extractor", cmd: "
-        : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
-        varPath=\"$DEEPDIVE_GROUNDING_DIR\"/variable/\(.variableName | @sh)
-        mkdir -p \"$varPath\"
-        cd \"$varPath\"
 
         deepdive db analyze \(.variablesTable | @sh)
 
@@ -57,12 +53,8 @@ def factorWeightDescriptionSqlExpr:
         , GROUP_BY: [ .variablesCategoryColumns[] |         { table: "v", column: . }   ]
         } | asSql | asPrettySqlArg)
         # assign unique id to every distinct category
-        deepdive db assign_sequential_id \(.variablesCategoriesTable | @sh) cid 0 1 \(
-            # order by category columns to keep the cids and wids in sync
-            [ .variablesCategoryColumns[]
-            | { column: "_\(.)" }
-            | asSqlExpr
-            ] | join(", ") | @sh)
+
+        deepdive db assign_sequential_id \(.variablesCategoriesTable | @sh) cid
 
         deepdive db analyze \(.variablesCategoriesTable | @sh)
 
@@ -73,7 +65,7 @@ def factorWeightDescriptionSqlExpr:
         deepdive create table \(.variablesIdsTable | @sh) as \(
         { SELECT:
             [ (.variablesKeyColumns[]
-            | { alias: ., table: "v", column: . }) # XXX we don't prefix user's columns (with _ like others) since they directly use this table and it can cause confusion
+            | { alias: ., table: "v", column: . })
             , { alias: deepdiveVariableInternalLabelColumn, expr:
                 # boolean variables just take one label, so aggregate with AND
                 ( if .variableType == "boolean" then "EVERY(\"v\".\(.variablesLabelColumn | asSqlIdent))"
@@ -81,6 +73,12 @@ def factorWeightDescriptionSqlExpr:
                 else "MIN(CASE WHEN \"v\".\(.variablesLabelColumn | asSqlIdent) THEN \"c\".\"cid\" ELSE NULL END)"
                 end) }
             , { alias: deepdiveVariableInternalFrequencyColumn, expr: "COUNT(1)" }
+            , { alias: deepdiveVariableInternalPartitionColumn, expr:
+                (if (.variablesParitionColumns | any) then
+                    "((" +
+                    ([ .variablesParitionColumns[] | "('x'||substr(coalesce(md5(\(.)::text),''),1,8))::bit(32)"]
+                     | join(" # ")) + ")::BIGINT % \($deepdive.sampler.partitions))::INT"
+                else "0::INT" end) }
             , { alias: deepdiveVariableIdColumn, expr: "CAST(NULL AS BIGINT)" }
             ]
         , FROM: [ { alias: "v", table: .variablesTable } ]
@@ -103,61 +101,22 @@ def factorWeightDescriptionSqlExpr:
     }
 })
 
-## variable_id_partition
-# Grounding begins by counting the variables to partition a range of
-# non-negative integers for assigning the variable ids.
+
+## variable_assign_id
 | .deepdive_.execution.processes += {
-    "process/grounding/variable_id_partition": {
+    "process/grounding/variable_assign_id": {
         dependencies_: [
-            # id partition depends on all distinct variables to be first identified
             $deepdive.schema.variables_[] | "process/grounding/variable/\(.variableName)/materialize"
         ],
         style: "cmd_extractor", cmd: "
-        : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
+            deepdive db assign_sequential_id \([$deepdive.schema.variables_[] | .variablesIdsTable] | join(",") | @sh) \(deepdiveVariableIdColumn | @sh) \(deepdiveVariableInternalPartitionColumn | @sh)
 
-        RANGE_BEGIN=0 \\
-        partition_id_range \($deepdive.schema.variables_ | map(.variablesIdsTable | @sh) | join(" ")) | {
-            # variable names
-            set -- \($deepdive.schema.variables_ | map(.variableName | @sh) | join(" "))
-            # record the base
-            variableCountTotal=0
-            while read table begin excludeEnd; do
-                varName=$1; shift
-                varPath=\"$DEEPDIVE_GROUNDING_DIR\"/variable/${varName}
-                mkdir -p \"$varPath\"
-                cd \"$varPath\"
-                echo $begin                      >id_begin
-                echo $excludeEnd                 >id_exclude_end
-                echo $(( $excludeEnd - $begin )) >count
-                variableCountTotal=$excludeEnd
-            done
-            # record the final count
-            echo $variableCountTotal >\"$DEEPDIVE_GROUNDING_DIR\"/variable_count
-        }
+            \([$deepdive.schema.variables_[]
+                | "deepdive db analyze \(.variablesIdsTable | @sh)"]
+            | join("\n"))
         "
     }
 }
-
-
-## variable/*/assign_id
-# Each variable table then gets the range of integers assigned to the id column
-# of every row.
-| .deepdive_.execution.processes += merge($deepdive.schema.variables_[] | {
-    "process/grounding/variable/\(.variableName)/assign_id": {
-        dependencies_: [
-            "process/grounding/variable_id_partition"
-        ],
-        style: "cmd_extractor", cmd: "
-        : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
-
-        cd \"$DEEPDIVE_GROUNDING_DIR\"/variable/\(.variableName | @sh)
-        baseId=$(cat id_begin)
-
-        # assign id to all distinct variables according to the paritition
-        deepdive db assign_sequential_id \(.variablesIdsTable | @sh) \(deepdiveVariableIdColumn | @sh) $baseId
-        "
-    }
-})
 
 ## variable_holdout
 # Variables to holdout are recorded by executing either a user-defined
@@ -167,11 +126,9 @@ def factorWeightDescriptionSqlExpr:
 | .deepdive_.execution.processes += {
     "process/grounding/variable_holdout": {
         dependencies_: [
-            $deepdive.schema.variables_[]
-            | "process/grounding/variable/\(.variableName)/assign_id"
+            "process/grounding/variable_assign_id"
         ],
         style: "cmd_extractor", cmd: "
-        : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
 
         deepdive create table \(deepdiveGlobalHoldoutTable | @sh) \\
             variable_id:BIGINT:'PRIMARY KEY' \\
@@ -208,14 +165,16 @@ def factorWeightDescriptionSqlExpr:
     }
 }
 
+
 ## variable/*/dump
 # Then each variable table is dumped into a set of binary files for the inference engine.
-| .deepdive_.execution.processes += merge($deepdive.schema.variables_[] | {
-    "process/grounding/variable/\(.variableName)/dump": {
+| .deepdive_.execution.processes += merge($deepdive.schema.variables_[]
+    | . as $var
+    | [range($deepdive.sampler.partitions) | {pid: .} + $var][]
+    | {
+    "process/grounding/variable/\(.variableName)/\(.pid)/dump": {
         dependencies_: [
             "process/grounding/variable_holdout"
-          # XXX below can be omitted for now
-          #, "process/grounding/variable/\(.variableName)/assign_id"
         ],
         style: "cmd_extractor", cmd: "
         : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
@@ -223,7 +182,7 @@ def factorWeightDescriptionSqlExpr:
         varPath=\"$DEEPDIVE_GROUNDING_DIR\"/variable/\(.variableName | @sh)
         mkdir -p \"$varPath\"
         cd \"$varPath\"
-        find . -name 'variables.part-*.bin.bz2' -exec rm -rf {} +
+        find . -name 'variables.\(.pid).part-*.bin.bz2' -exec rm -rf {} +
         export DEEPDIVE_LOAD_FORMAT=tsv
         export DEEPDIVE_UNLOAD_MATERIALIZED=false
 
@@ -247,7 +206,7 @@ def factorWeightDescriptionSqlExpr:
                 ]
             , FROM: { alias: "variables", sql:
                 { SELECT:
-                    [ { alias: "vid", table: "i", column: deepdiveVariableIdColumn }
+                    [ { alias: "vid", expr: "i.\(deepdiveVariableIdColumn | asSqlIdent) & ((1::bigint << 48) - 1)" }
                     , { alias: "variable_role", expr:
                           "CASE WHEN observation.variable_id IS NOT NULL
                                  AND \"i\".\(deepdiveVariableInternalLabelColumn | asSqlIdent) IS NOT NULL THEN 2
@@ -276,10 +235,17 @@ def factorWeightDescriptionSqlExpr:
                       , ON: { eq: [ { table: "i"  , column: deepdiveVariableIdColumn }
                                   , { table: "observation", column: "variable_id" } ] } }
                     ]
+                , WHERE:
+                    [ { eq: [ { table: "i", column: deepdiveVariableInternalPartitionColumn }
+                            , { expr: .pid }
+                            ]
+                      }
+                    ]
                 } }
             } | asSql | asPrettySqlArg) \\
             command=\("
-                sampler-dw text2bin variable /dev/stdin >(pbzip2 >variables.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2)
+                sampler-dw text2bin variable /dev/stdin >(pbzip2 >variables.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2) |
+                tee nvars.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}
             " | @sh) \\
             output_relation=
         "
@@ -291,17 +257,20 @@ def factorWeightDescriptionSqlExpr:
 ## variable/*/dump_domains
 # Each categorical variable dumps an extra input for the inference engine that holds the domains.
 | .deepdive_.execution.processes += merge($deepdive.schema.variables_[]
-    | select(.variableType == "categorical") | {
-    "process/grounding/variable/\(.variableName)/dump_domains": {
+    | select(.variableType == "categorical")
+    | . as $var
+    | [range($deepdive.sampler.partitions) | {pid: .} + $var][]
+    | {
+    "process/grounding/variable/\(.variableName)/\(.pid)/dump_domains": {
         dependencies_: [
-            "process/grounding/variable/\(.variableName)/assign_id"
+            "process/grounding/variable_assign_id"
         ],
         style: "cmd_extractor", cmd: "
         : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
         varPath=\"$DEEPDIVE_GROUNDING_DIR\"/variable/\(.variableName | @sh)
         mkdir -p \"$varPath\"
         cd \"$varPath\"
-        find . -name 'domains.part-*.bin.bz2' -exec rm -rf {} +
+        find . -name 'domains.\(.pid).part-*.bin.bz2' -exec rm -rf {} +
         export DEEPDIVE_LOAD_FORMAT=tsv
         export DEEPDIVE_UNLOAD_MATERIALIZED=false
 
@@ -310,7 +279,7 @@ def factorWeightDescriptionSqlExpr:
         input_sql=\(
         # sparse categorical variables have domains files
         { SELECT:
-            [ { alias: "vid",  table: "i", column: deepdiveVariableIdColumn }
+            [ { alias: "vid", expr: "i.\(deepdiveVariableIdColumn | asSqlIdent) & ((1::bigint << 48) - 1)" }
             , { alias: "cardinality", expr: "COUNT(c.cid)" }
             , { alias: "cids", expr: "ARRAY_AGG(c.cid ORDER BY c.cid)" }
             , { alias: "truthiness", expr: "ARRAY_AGG(COALESCE(v.\(deepdiveVariableLabelTruthinessColumn), 0) ORDER BY c.cid)" }
@@ -332,10 +301,16 @@ def factorWeightDescriptionSqlExpr:
                                     ] }
                             ] } }
             ]
+        , WHERE:
+            [ { eq: [ { table: "i", column: deepdiveVariableInternalPartitionColumn }
+                    , { expr: .pid }
+                    ]
+              }
+            ]
         , GROUP_BY: [ { table: "i", column: deepdiveVariableIdColumn } ]
         } | asSql | asPrettySqlArg) \\
         command=\("
-            sampler-dw text2bin domain /dev/stdin /dev/stdout | pbzip2 >domains.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
+            sampler-dw text2bin domain /dev/stdin /dev/stdout | pbzip2 >domains.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
         " | @sh) \\
         output_relation=
         "
@@ -350,29 +325,18 @@ def factorWeightDescriptionSqlExpr:
 # Each inference rule's SQL query is run to materialize the factors and the
 # distinct weights used in them.
 | .deepdive_.execution.processes += merge($deepdive.inference.factors_[]
-    | [ .input_[]
-      | ltrimstr("data/")
-      | $deepdive.schema.variables_byName[.]
-      | select(type != "null")
-      ] as $schemaVariablesForThisFactor
     | {
     # add a process for grounding factors
     "process/grounding/factor/\(.factorName)/materialize": {
         # materializing each factor requires the dependent variables to have their id assigned
         dependencies_: [
-            $schemaVariablesForThisFactor[]
-            # the involved variables must have their ids all assigned
-            | "process/grounding/variable/\(.variableName)/assign_id"?
+            "process/grounding/variable_assign_id"
         ],
         # other non-variable tables are also necessary
         input_: [ .input_[]
             | select(ltrimstr("data/") | in($deepdive.schema.variables_byName) | not)
         ],
         style: "cmd_extractor", cmd: "
-            : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
-            facPath=\"$DEEPDIVE_GROUNDING_DIR\"/factor/\(.factorName | @sh)
-            mkdir -p \"$facPath\"
-            cd \"$facPath\"
 
             # materialize factors using user input_query that pulls in assigned ids to involved variables
             deepdive create table \(.factorsTable | @sh) as \(
@@ -404,7 +368,7 @@ def factorWeightDescriptionSqlExpr:
                     , { alias: "initvalue", expr: .weight_.init_value    }
                     , { alias: "wid"      , expr: "CAST(NULL AS BIGINT)" } # to be assigned later by the assign_weight_id process
                     ]
-                , DISTINCT: true  # XXX this is inevitable
+                , DISTINCT: true
                 , FROM:
                     [ select(.weight_.params | length > 0)
                     # when weight is parameterized, find all distinct ones
@@ -418,62 +382,23 @@ def factorWeightDescriptionSqlExpr:
 })
 
 
-## weight_id_partition
-# The weight ids must be first partitioned by counting them.
+## assign_weight_id
+# Each inference rule gets its weight ids actually assigned.
 | .deepdive_.execution.processes += {
-    "process/grounding/weight_id_partition": {
+    "process/grounding/assign_weight_id": {
         dependencies_: [
             $deepdive.inference.factors_[]
             | "process/grounding/factor/\(.factorName)/materialize"
         ],
         style: "cmd_extractor", cmd: "
-        : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
-        cd \"$DEEPDIVE_GROUNDING_DIR\"/factor
+            deepdive db assign_sequential_id \([$deepdive.inference.factors_[] | .weightsTable] | join(",") | @sh) wid
 
-        \([ "set --", "\($deepdive.inference.factors_[].weightsTable | @sh)", "#" ] | join(" \\\n    "))
-
-        # partition the id range for weights
-        RANGE_BEGIN=0 RANGE_STEP=1 \\
-        partition_id_range \"$@\" | {
-            # factor names
-            set -- \($deepdive.inference.factors_ | map(.factorName | @sh) | join(" "))
-            weightsCountTotal=0
-            while read table begin excludeEnd; do
-                factor=$1; shift
-                facPath=\"$DEEPDIVE_GROUNDING_DIR\"/factor/${factor}
-                mkdir -p \"$facPath\"
-                cd \"$facPath\"
-                echo $begin                      >weights_id_begin
-                echo $excludeEnd                 >weights_id_exclude_end
-                echo $(( $excludeEnd - $begin )) >weights_count
-                weightsCountTotal=$excludeEnd
-            done
-            echo $weightsCountTotal >\"$DEEPDIVE_GROUNDING_DIR\"/factor/weights_count
-        }
+            \([$deepdive.inference.factors_[]
+                | "deepdive db analyze \(.weightsTable | @sh)"]
+            | join("\n"))
         "
     }
 }
-
-## factor/*/assign_weight_id
-# Each inference rule gets its weight ids actually assigned.
-| .deepdive_.execution.processes += merge($deepdive.inference.factors_[] | {
-    "process/grounding/factor/\(.factorName)/assign_weight_id": {
-        dependencies_: [
-            "process/grounding/weight_id_partition"
-        ],
-        style: "cmd_extractor", cmd: "
-            : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
-
-            cd \"$DEEPDIVE_GROUNDING_DIR\"/factor/\(.factorName | @sh)
-            baseId=$(cat weights_id_begin)
-
-            # assign weight ids according to the partition
-            deepdive db assign_sequential_id \(.weightsTable | @sh) wid $baseId
-
-            deepdive db analyze \(.weightsTable | @sh)
-        "
-    }
-})
 
 ## global_weight_table
 # To view the weights learned by the inference engine later, set up an app-wide table.
@@ -484,7 +409,6 @@ def factorWeightDescriptionSqlExpr:
                 "process/grounding/factor/\(.factorName)/materialize"
         ],
         style: "cmd_extractor", cmd: "
-        : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
 
         # set up a union view for all weight tables (\(deepdiveGlobalWeightsTable | asSqlIdent))
         deepdive create view \(deepdiveGlobalWeightsTable | @sh) as \(
@@ -506,20 +430,23 @@ def factorWeightDescriptionSqlExpr:
 
 ## factor/*/dump
 # The factors are dumped into a set of binary files for the inference engine.
-| .deepdive_.execution.processes += merge($deepdive.inference.factors_[] | {
+| .deepdive_.execution.processes += merge($deepdive.inference.factors_[]
+    | . as $fac
+    | [range($deepdive.sampler.partitions) | {pid: .} + $fac][]
+    | {
     # add a process for grounding factors and weights
-    "process/grounding/factor/\(.factorName)/dump": {
+    "process/grounding/factor/\(.factorName)/\(.pid)/dump": {
         dependencies_: [
-            "process/grounding/factor/\(.factorName)/assign_weight_id"
+            "process/grounding/assign_weight_id"
         ],
         style: "cmd_extractor", cmd: "
             : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
             facPath=\"$DEEPDIVE_GROUNDING_DIR\"/factor/\(.factorName | @sh)
             mkdir -p \"$facPath\"
             cd \"$facPath\"
-            find . \\( -name  'factors.part-*.bin.bz2' \\
-                    -o -name 'nfactors.part-*'         \\
-                    -o -name   'nedges.part-*'         \\
+            find . \\( -name  'factors.\(.pid).part-*.bin.bz2' \\
+                    -o -name 'nfactors.\(.pid).part-*'         \\
+                    -o -name   'nedges.\(.pid).part-*'         \\
                    \\) -exec rm -rf {} +
             export DEEPDIVE_LOAD_FORMAT=tsv
             export DEEPDIVE_UNLOAD_MATERIALIZED=false
@@ -540,7 +467,7 @@ def factorWeightDescriptionSqlExpr:
                     echo \(
                     { SELECT:
                         [ ( .function_.variables[]
-                        | { table: "f", column: .columnId } )
+                        | { expr: "f.\(.columnId | asSqlIdent) & ((1::bigint << 48) - 1)"} )
                         , ( .function_.variables[]
                         | { table: "C\(.ordinal)", column: "cid" } )
                         , { alias: "weight_id", table: "w", column: "wid" }
@@ -564,12 +491,14 @@ def factorWeightDescriptionSqlExpr:
                         [ ( .weight_.params[]
                         | { eq: [ { table: "w", column: . }
                                 , { table: "f", column: . } ] } )
+                        , { eq: [ { expr: "f.\(.function_.variables[0].columnId | asSqlIdent) >> 48" }
+                                , { expr: .pid }]}
                         ]
                     } | asSql | asPrettySqlArg)
                 )\"" else # factors over boolean variables
                     { SELECT:
                         [ ( .function_.variables[]
-                        | { table: "f", column: .columnId } )
+                        | { expr: "f.\(.columnId | asSqlIdent) & ((1::bigint << 48) - 1)"} )
                         , { alias: "weight_id", table: "w", column: "wid" }
                         , { alias: "feature_value", table: "f", column: "feature_value" }
                         ]
@@ -581,18 +510,20 @@ def factorWeightDescriptionSqlExpr:
                         [ ( .weight_.params[]
                         | { eq: [ { table: "w", column: . }
                                 , { table: "f", column: . } ] } )
+                        , { eq: [ { expr: "f.\(.function_.variables[0].columnId | asSqlIdent) >> 48" }
+                                , { expr: .pid }]}
                         ]
                     } | asSql | asPrettySqlArg
                 end) \\
                 command=\("
                     # also record the factor count
-                    tee >(wc -l >nfactors.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}) |
-                    sampler-dw text2bin factor /dev/stdin >(pbzip2 >factors.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2) \\
+                    tee >(wc -l >nfactors.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}) |
+                    sampler-dw text2bin factor /dev/stdin >(pbzip2 >factors.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2) \\
                         $\(.function_.name)Factor \\
                         $numVariablesForFactor \\
                         $areVariablesPositive |
                     # and the edge count
-                    tee nedges.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}
+                    tee nedges.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}
                 " | @sh) \\
                 output_relation=
         "
@@ -605,7 +536,7 @@ def factorWeightDescriptionSqlExpr:
     # add a process for grounding factors and weights
     "process/grounding/factor/\(.factorName)/dump_weights": {
         dependencies_: [
-            "process/grounding/factor/\(.factorName)/assign_weight_id"
+            "process/grounding/assign_weight_id"
         ],
         style: "cmd_extractor", cmd: "
             : ${DEEPDIVE_GROUNDING_DIR:=\"$DEEPDIVE_APP\"/run/model/grounding}
@@ -618,7 +549,7 @@ def factorWeightDescriptionSqlExpr:
             export DEEPDIVE_UNLOAD_MATERIALIZED=false
 
             # flag that signals whether to reuse weights or not
-            reuseFlag=\"$DEEPDIVE_GROUNDING_DIR\"/factor/weights.reuse
+            reuseFlag=\"$DEEPDIVE_GROUNDING_DIR\"/weights.reuse
 
             # dump the weights (except the description column), converting into binary format for the inference engine
             deepdive compute execute \\
@@ -649,7 +580,8 @@ def factorWeightDescriptionSqlExpr:
                     } | asSql | asPrettySqlArg)
                 fi)\" \\
                 command=\("
-                    sampler-dw text2bin weight /dev/stdin >(pbzip2 >weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2)
+                    sampler-dw text2bin weight /dev/stdin >(pbzip2 >weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2) |
+                    tee nweights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}
                 " | @sh) \\
                 output_relation=
         "
@@ -663,13 +595,19 @@ def factorWeightDescriptionSqlExpr:
     "process/grounding/combine_factorgraph": {
         dependencies_: [(
             $deepdive.schema.variables_[]
-            | "process/grounding/variable/\(.variableName)/dump"
+            | . as $var
+            | [range($deepdive.sampler.partitions) | {pid: .} + $var][]
+            | "process/grounding/variable/\(.variableName)/\(.pid)/dump"
             , (select(.variableType == "categorical")
-            | "process/grounding/variable/\(.variableName)/dump_domains")
+            | "process/grounding/variable/\(.variableName)/\(.pid)/dump_domains")
         ), (
             $deepdive.inference.factors_[]
-            | "process/grounding/factor/\(.factorName)/dump"
-            , "process/grounding/factor/\(.factorName)/dump_weights"
+            | . as $fac
+            | [range($deepdive.sampler.partitions) | {pid: .} + $fac][]
+            | "process/grounding/factor/\(.factorName)/\(.pid)/dump"
+        ), (
+            $deepdive.inference.factors_[]
+            | "process/grounding/factor/\(.factorName)/dump_weights"
         ), (
             "process/grounding/global_weight_table"
         )],
@@ -684,43 +622,48 @@ def factorWeightDescriptionSqlExpr:
         # create a fresh empty directory for the new combined factor graph
         rm -rf   \"$DEEPDIVE_FACTORGRAPH_DIR\"
         mkdir -p \"$DEEPDIVE_FACTORGRAPH_DIR\"
-        cd \"$DEEPDIVE_FACTORGRAPH_DIR\"
-
-        # create symlinks to the grounded binaries by enumerating variables and factors
-        for v in \($variableNames); do
-            mkdir -p {variables,domains}/\"$v\"
-            find \"$DEEPDIVE_GROUNDING_DIR\"/variable/\"$v\" \\
-                -name 'variables.part-*.bin.bz2' -exec ln -sfnv -t variables/\"$v\"/ {} + \\
-                -o \\
-                -name   'domains.part-*.bin.bz2' -exec ln -sfnv -t   domains/\"$v\"/ {} + \\
-                #
-        done
-        for f in \($factorNames); do
-            mkdir -p {factors,weights}/\"$f\"
-            find \"$DEEPDIVE_GROUNDING_DIR\"/factor/\"$f\" \\
-                -name 'factors.part-*.bin.bz2' -exec ln -sfnv -t factors/\"$f\"/ {} + \\
-                -o \\
-                -name 'weights.part-*.bin.bz2' -exec ln -sfnv -t weights/\"$f\"/ {} + \\
-                #
-        done
 
         # generate the metadata for the inference engine
-        {
-            # first line with counts of variables and edges in the grounded factor graph
-            cd \"$DEEPDIVE_GROUNDING_DIR\"
-            sumup() { { tr '\\n' +; echo 0; } | bc; }
-            counts=()
-            counts+=($(cat factor/weights_count))
-            # sum up the number of factors and edges
-            counts+=($(cat variable_count))
-            cd factor
-            counts+=($(find \($factorNames) -name 'nfactors.part-*' -exec cat {} + | sumup))
-            counts+=($(find \($factorNames) -name 'nedges.part-*'   -exec cat {} + | sumup))
-            (IFS=,; echo \"${counts[*]}\")
-            # second line with file paths
-            paths=(\"$DEEPDIVE_FACTORGRAPH_DIR\"/{weights,variables,factors,edges,domains})
-            (IFS=,; echo \"${paths[*]}\")
-        } >meta
+        for pid in $(seq 0 \($deepdive.sampler.partitions - 1)); do
+            cd \"$DEEPDIVE_FACTORGRAPH_DIR\"
+            mkdir -p $pid
+            cd $pid
+            # create symlinks to the grounded binaries by enumerating variables and factors
+            for v in \($variableNames); do
+                mkdir -p {variables,domains}/\"$v\"
+                find \"$DEEPDIVE_GROUNDING_DIR\"/variable/\"$v\" \\
+                    -name \"variables.$pid.part-*.bin.bz2\" -exec ln -sfnv -t variables/\"$v\"/ {} + \\
+                    -o \\
+                    -name \"domains.$pid.part-*.bin.bz2\" -exec ln -sfnv -t   domains/\"$v\"/ {} + \\
+                    #
+            done
+            for f in \($factorNames); do
+                mkdir -p {factors,weights}/\"$f\"
+                find \"$DEEPDIVE_GROUNDING_DIR\"/factor/\"$f\" \\
+                    -name \"factors.$pid.part-*.bin.bz2\" -exec ln -sfnv -t factors/\"$f\"/ {} + \\
+                    -o \\
+                    -name 'weights.part-*.bin.bz2' -exec ln -sfnv -t weights/\"$f\"/ {} + \\
+                    #
+            done
+
+            {
+                # first line with counts of variables and edges in the grounded factor graph
+                cd \"$DEEPDIVE_GROUNDING_DIR\"
+                sumup() { { tr '\\n' +; echo 0; } | bc; }
+                counts=()
+                cd factor
+                counts+=($(find \($factorNames) -name 'nweights.part-*' -exec cat {} + | sumup))
+                cd ../variable
+                counts+=($(find \($variableNames) -name \"nvars.$pid.part-*\" -exec cat {} + | sumup))
+                cd ../factor
+                counts+=($(find \($factorNames) -name \"nfactors.$pid.part-*\" -exec cat {} + | sumup))
+                counts+=($(find \($factorNames) -name \"nedges.$pid.part-*\"   -exec cat {} + | sumup))
+                (IFS=,; echo \"${counts[*]}\")
+                # second line with file paths
+                paths=(\"$DEEPDIVE_FACTORGRAPH_DIR\"/{weights,variables,factors,edges,domains})
+                (IFS=,; echo \"${paths[*]}\")
+            } > \"$DEEPDIVE_FACTORGRAPH_DIR/$pid/meta\"
+        done
         ")
     }
 }

--- a/compiler/compile-config/compile-config-2.01-grounding
+++ b/compiler/compile-config/compile-config-2.01-grounding
@@ -245,8 +245,7 @@ def factorWeightDescriptionSqlExpr:
                 } }
             } | asSql | asPrettySqlArg) \\
             command=\("
-                sampler-dw text2bin variable /dev/stdin >(pbzip2 >variables.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2) |
-                tee nvars.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}
+                sampler-dw text2bin variable /dev/stdin /dev/stdout nvars.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX} | pbzip2 >variables.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
             " | @sh) \\
             output_relation=
         "
@@ -311,7 +310,7 @@ def factorWeightDescriptionSqlExpr:
         , GROUP_BY: [ { table: "i", column: deepdiveVariableIdColumn } ]
         } | asSql | asPrettySqlArg) \\
         command=\("
-            sampler-dw text2bin domain /dev/stdin /dev/stdout | pbzip2 >domains.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
+            sampler-dw text2bin domain /dev/stdin /dev/stdout /dev/null | pbzip2 >domains.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
         " | @sh) \\
         output_relation=
         "
@@ -519,12 +518,11 @@ def factorWeightDescriptionSqlExpr:
                 command=\("
                     # also record the factor count
                     tee >(wc -l >nfactors.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}) |
-                    sampler-dw text2bin factor /dev/stdin >(pbzip2 >factors.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2) \\
+                    sampler-dw text2bin factor /dev/stdin /dev/stdout nedges.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX} \\
                         $\(.function_.name)Factor \\
                         $numVariablesForFactor \\
-                        $areVariablesPositive |
-                    # and the edge count
-                    tee nedges.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}
+                        $areVariablesPositive \\
+                        | pbzip2 >factors.\(.pid).part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
                 " | @sh) \\
                 output_relation=
         "
@@ -582,8 +580,7 @@ def factorWeightDescriptionSqlExpr:
                     } | asSql | asPrettySqlArg)
                 fi)\" \\
                 command=\("
-                    sampler-dw text2bin weight /dev/stdin >(pbzip2 >weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2) |
-                    tee nweights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}
+                    sampler-dw text2bin weight /dev/stdin /dev/stdout nweights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX} | pbzip2 >weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
                 " | @sh) \\
                 output_relation=
         "

--- a/compiler/compile-config/compile-config-2.01-grounding
+++ b/compiler/compile-config/compile-config-2.01-grounding
@@ -183,6 +183,7 @@ def factorWeightDescriptionSqlExpr:
         mkdir -p \"$varPath\"
         cd \"$varPath\"
         find . -name 'variables.\(.pid).part-*.bin.bz2' -exec rm -rf {} +
+        find . -name 'nvars.\(.pid).part-*' -exec rm -rf {} +
         export DEEPDIVE_LOAD_FORMAT=tsv
         export DEEPDIVE_UNLOAD_MATERIALIZED=false
 
@@ -544,6 +545,7 @@ def factorWeightDescriptionSqlExpr:
             mkdir -p \"$facPath\"
             cd \"$facPath\"
             find . \\( -name  'weights.part-*.bin.bz2' \\
+                    -o -name  'nweights.part-*'        \\
                    \\) -exec rm -rf {} +
             export DEEPDIVE_LOAD_FORMAT=tsv
             export DEEPDIVE_UNLOAD_MATERIALIZED=false

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -108,7 +108,7 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                                 }
                         } | asSql | asPrettySqlArg) \\
                     command=\("
-                        sampler-dw text2bin weight /dev/stdin /dev/stdout | pbzip2 >$TARGET_WEIGHT_DIR/weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
+                        sampler-dw text2bin weight /dev/stdin /dev/stdout /dev/null | pbzip2 >$TARGET_WEIGHT_DIR/weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
                     " | @sh) \\
                     output_relation=
 

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -108,7 +108,7 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                                 }
                         } | asSql | asPrettySqlArg) \\
                     command=\("
-                        sampler-dw text2bin weight /dev/stdin >(pbzip2 >$TARGET_WEIGHT_DIR/weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2)
+                        sampler-dw text2bin weight /dev/stdin /dev/stdout | pbzip2 >$TARGET_WEIGHT_DIR/weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
                     " | @sh) \\
                     output_relation=
 

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -14,39 +14,120 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
     # learning weights and doing inference (since we had to load the graph anyway)
     "process/model/learning": {
         dependencies_: ["model/factorgraph"],
-        output_: ["model/weights"],
+        output_: ["model/weights", "data/model/weights"],
         style: "cmd_extractor",
-        cmd: ": ${DEEPDIVE_NUM_PROCESSES:=$(nproc --ignore=1)}
-            mkdir -p ../../../model && cd ../../../model
-            mkdir -p weights
-            [ -d factorgraph ] || error \"No factorgraph found\"
+        cmd: "
+        export DEEPDIVE_LOAD_FORMAT=tsv
+        : ${DEEPDIVE_NUM_PROCESSES:=$(nproc --ignore=1)}
+        : ${DEEPDIVE_RESULTS_DIR:=\"$DEEPDIVE_APP\"/run/model/results}
+        : ${DEEPDIVE_FACTORGRAPH_DIR:=\"$DEEPDIVE_APP\"/run/model/factorgraph}
+
+        flatten() { find -L \"$@\" -type f -size +0 -exec pbzip2 -c -d -k {} +; }
+
+        for pid in $(seq 0 \($deepdive.sampler.partitions - 1)); do
+            mkdir -p $DEEPDIVE_RESULTS_DIR/$pid
+            cd $DEEPDIVE_RESULTS_DIR/$pid
+
+            FGDIR=$DEEPDIVE_FACTORGRAPH_DIR/$pid
+
+            [ -d $FGDIR ] || error \"No factorgraph found\"
+
             # run inference engine for learning and inference
-            flatten() { find -L \"$@\" -type f -size +0 -exec pbzip2 -c -d -k {} +; }
+
+            if [ $pid -gt 0 ]; then
+                # use weights learned from previous shard
+                WEIGHT_DIR=weights_hot
+            else
+                WEIGHT_DIR=weights
+            fi
+
+            # if there are multiple shards, we suppress inference (-i 0)
 
             \(if $deepdive.sampler.sampler_cmd == "numbskull" then "
-                mkdir -p flat
-                head -n 1 factorgraph/meta > flat/graph.meta
+                mkdir -p $FGDIR/flat
+                head -n 1 $FGDIR/meta > $FGDIR/flat/graph.meta
                 # TODO: save disk space
-                flatten factorgraph/variables > flat/graph.variables
-                flatten factorgraph/factors > flat/graph.factors
-                flatten factorgraph/weights > flat/graph.weights
-                flatten factorgraph/domains > flat/graph.domains
-                numbskull flat --output_dir weights --threads $DEEPDIVE_NUM_PROCESSES \($deepdive.sampler.sampler_args // "#")
+                flatten $FGDIR/variables > $FGDIR/flat/graph.variables
+                flatten $FGDIR/factors > $FGDIR/flat/graph.factors
+                flatten $FGDIR/$WEIGHT_DIR > $FGDIR/flat/graph.weights
+                flatten $FGDIR/domains > $FGDIR/flat/graph.domains
+                numbskull $FGDIR/flat \\
+                    --output_dir . \\
+                    --threads $DEEPDIVE_NUM_PROCESSES \\
+                    \($deepdive.sampler.sampler_args // "") \\
+                    \(if $deepdive.sampler.partitions > 1 then "-i 0" else "" end) \\
+                    #
             " else "
-                \($deepdive.sampler.sampler_cmd // "sampler-dw") \\
+                \($deepdive.sampler.sampler_cmd) \\
                     gibbs \\
-                    --variables <(flatten factorgraph/variables) \\
-                    --domains <(flatten factorgraph/domains) \\
-                    --factors <(flatten factorgraph/factors) \\
-                    --weights <(flatten factorgraph/weights) \\
-                    --fg_meta factorgraph/meta \\
-                    --outputFile weights \\
+                    --variables <(flatten $FGDIR/variables) \\
+                    --domains <(flatten $FGDIR/domains) \\
+                    --factors <(flatten $FGDIR/factors) \\
+                    --weights <(flatten $FGDIR/$WEIGHT_DIR) \\
+                    --fg_meta $FGDIR/meta \\
+                    --outputFile . \\
                     --n_threads $DEEPDIVE_NUM_PROCESSES \\
-                    \($deepdive.sampler.sampler_args // "#")
+                    \($deepdive.sampler.sampler_args // "") \\
+                    \(if $deepdive.sampler.partitions > 1 then "-i 0" else "" end) \\
+                    #
             " end)
 
-            mkdir -p probabilities
-            mv -f weights/inference_result.out.text probabilities/
+            # load weights to database
+            deepdive create table \(deepdiveInferenceResultWeightsTable | @sh) \\
+                wid:BIGINT:'PRIMARY KEY' \\
+                weight:'DOUBLE PRECISION' \\
+                #
+            cat inference_result.out.weights.text |
+            tr \(" "|@sh) \("\\t"|@sh) |
+            deepdive load \(deepdiveInferenceResultWeightsTable | @sh) /dev/stdin
+            deepdive db analyze \(deepdiveInferenceResultWeightsTable | @sh)
+            mv inference_result.out.weights.text inference_result.out.weights.text.learned
+
+            \(if $deepdive.sampler.partitions > 1 then "
+                # dump weights back out for next-shard learning or inference step
+                if [ $pid -lt \($deepdive.sampler.partitions - 1) ]; then
+                    # not last shard: dump for next-shard learning
+                    export TARGET_WEIGHT_DIR=$DEEPDIVE_FACTORGRAPH_DIR/$(($pid+1))/weights_hot
+                else
+                    export TARGET_WEIGHT_DIR=$DEEPDIVE_FACTORGRAPH_DIR/learned_weights
+                fi
+
+                mkdir -p $TARGET_WEIGHT_DIR
+                deepdive compute execute \\
+                    input_sql=\(
+                        { SELECT:
+                            [ { table: "w", column: "wid" }
+                            , { expr: "CASE WHEN isfixed THEN 1 ELSE 0 END" }
+                            , { expr: "COALESCE(r.weight, w.initvalue, 0)" }
+                            ]
+                        , FROM: [ { alias: "w", table: deepdiveGlobalWeightsTable } ]
+                        , JOIN: { LEFT_OUTER: { alias: "r", table: deepdiveInferenceResultWeightsTable }
+                                , ON: { eq: [ { table: "r", column: "wid" }
+                                            , { table: "w", column: "wid" }
+                                            ] }
+                                }
+                        } | asSql | asPrettySqlArg) \\
+                    command=\("
+                        sampler-dw text2bin weight /dev/stdin >(pbzip2 >$TARGET_WEIGHT_DIR/weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2)
+                    " | @sh) \\
+                    output_relation=
+
+            " else "" end)
+
+        done
+
+        deepdive create view \(deepdiveInferenceResultWeightsMappingView | @sh) as \(
+            { SELECT:
+                [ { expr: "\"w\".*" }
+                , { table: "r", column: "weight" }
+                ]
+            , FROM: { alias: "w", table: deepdiveGlobalWeightsTable }
+            , JOIN: { INNER: { alias: "r", table: deepdiveInferenceResultWeightsTable }
+                    , ON: { eq: [ { table: "r", column: "wid" }
+                                , { table: "w", column: "wid" }
+                                ] } }
+            , ORDER_BY: { expr: "ABS(\"r\".\"weight\")", order: "DESC" }
+            } | asSql | asPrettySqlArg)
         "
     },
 
@@ -55,89 +136,93 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
         dependencies_: ["model/factorgraph", "model/weights"],
         output_: ["model/probabilities"],
         style: "cmd_extractor",
-        cmd: ": ${DEEPDIVE_NUM_PROCESSES:=$(nproc --ignore=1)}
-            mkdir -p ../../../model && cd ../../../model
-            [ -d factorgraph ] || error \"No factorgraph found\"
-            if [[ factorgraph/weights -nt probabilities/inference_result.out.text ]]; then
-                # no need to run inference unless the weights are fresher
+        cmd: "
+        : ${DEEPDIVE_NUM_PROCESSES:=$(nproc --ignore=1)}
+        : ${DEEPDIVE_RESULTS_DIR:=\"$DEEPDIVE_APP\"/run/model/results}
+        : ${DEEPDIVE_FACTORGRAPH_DIR:=\"$DEEPDIVE_APP\"/run/model/factorgraph}
+
+        flatten() { find -L \"$@\" -type f -size +0 -exec pbzip2 -c -d -k {} +; }
+
+        # need to run inference only if learning step was deferred because there are multiple shards
+        \(if $deepdive.sampler.partitions > 1 then "
+            for pid in $(seq 0 \($deepdive.sampler.partitions - 1)); do
+
+                mkdir -p $DEEPDIVE_RESULTS_DIR/$pid
+                cd $DEEPDIVE_RESULTS_DIR/$pid
+
+                FGDIR=$DEEPDIVE_FACTORGRAPH_DIR/$pid
+
+                [ -d $FGDIR ] || error \"No factorgraph found\"
+
                 # XXX this skipping may cause confusion
-                # run sampler for performing inference with given weights without learning
-                flatten() { find -L \"$@\" -type f -size +0 -exec pbzip2 -c -d -k {} +; }
+                # run sampler for inference with given weights without learning
+                LEARNED_WEIGHTS=$DEEPDIVE_FACTORGRAPH_DIR/learned_weights
 
                 \(if $deepdive.sampler.sampler_cmd == "numbskull" then "
-                    mkdir -p flat
-                    head -n 1 factorgraph/meta > flat/graph.meta
-                    # TODO: save disk space
-                    flatten factorgraph/variables > flat/graph.variables
-                    flatten factorgraph/factors > flat/graph.factors
-                    flatten factorgraph/weights > flat/graph.weights
-                    flatten factorgraph/domains > flat/graph.domains
-                    numbskull flat --output_dir weights --threads $DEEPDIVE_NUM_PROCESSES \($deepdive.sampler.sampler_args // "") -l 0  #
+                    mkdir -p $FGDIR/flat
+                    if [ $FGDIR/meta -nt $FGDIR/flat/graph.meta ]; then
+                        head -n 1 $FGDIR/meta > $FGDIR/flat/graph.meta
+                        flatten $FGDIR/variables > $FGDIR/flat/graph.variables
+                        flatten $FGDIR/factors > $FGDIR/flat/graph.factors
+                        flatten $FGDIR/domains > $FGDIR/flat/graph.domains
+                    fi
+                    flatten $LEARNED_WEIGHTS > $FGDIR/flat/graph.weights
+                    numbskull $FGDIR/flat \\
+                        --output_dir . \\
+                        --threads $DEEPDIVE_NUM_PROCESSES \\
+                        \($deepdive.sampler.sampler_args // "") \\
+                        -l 0 \\
+                        #
                 " else "
-                    \($deepdive.sampler.sampler_cmd // "sampler-dw") \\
+                    \($deepdive.sampler.sampler_cmd) \\
                         gibbs \\
-                        --variables <(flatten factorgraph/variables) \\
-                        --domains <(flatten factorgraph/domains) \\
-                        --factors <(flatten factorgraph/factors) \\
-                        --weights <(flatten factorgraph/weights) \\
-                        --fg_meta factorgraph/meta \\
-                        --outputFile weights \\
+                        --variables <(flatten $FGDIR/variables) \\
+                        --domains <(flatten $FGDIR/domains) \\
+                        --factors <(flatten $FGDIR/factors) \\
+                        --weights <(flatten $LEARNED_WEIGHTS) \\
+                        --fg_meta $FGDIR/meta \\
+                        --outputFile . \\
                         --n_threads $DEEPDIVE_NUM_PROCESSES \\
                         \($deepdive.sampler.sampler_args // "") \\
                         -l 0 \\
                         #
                 " end)
 
-                mkdir -p probabilities
-                mv -f weights/inference_result.out.text probabilities/
-            fi
+            done
+
+        " else "
+            echo Skipping process/model/inference because it was inlined in process/model/learning
+        " end)
         "
     },
 
-    # loading learning/inference results back to database
-    "process/model/load_weights": {
-        dependencies_: ["model/weights"],
-        output_: ["data/model/weights"],
-        style: "cmd_extractor",
-        cmd: "mkdir -p ../../../model && cd ../../../model
-            # load weights to database
-            deepdive create table \(deepdiveInferenceResultWeightsTable | @sh) \\
-                wid:BIGINT:'PRIMARY KEY' \\
-                weight:'DOUBLE PRECISION' \\
-                #
-            cat weights/inference_result.out.weights.text |
-            tr \(" "|@sh) \("\\t"|@sh) | DEEPDIVE_LOAD_FORMAT=tsv \\
-            deepdive load \(deepdiveInferenceResultWeightsTable | @sh) /dev/stdin
-
-            # create views
-            deepdive create view \(deepdiveInferenceResultWeightsMappingView | @sh) as \(
-                { SELECT:
-                    [ { expr: "\"w\".*" }
-                    , { table: "r", column: "weight" }
-                    ]
-                , FROM: { alias: "w", table: deepdiveGlobalWeightsTable }
-                , JOIN: { INNER: { alias: "r", table: deepdiveInferenceResultWeightsTable }
-                        , ON: { eq: [ { table: "r", column: "wid" }
-                                    , { table: "w", column: "wid" }
-                                    ] } }
-                , ORDER_BY: { expr: "ABS(\"r\".\"weight\")", order: "DESC" }
-                } | asSql | asPrettySqlArg)
-        "
-    },
     "process/model/load_probabilities": {
         dependencies_: ["model/probabilities"],
         output_: ["data/model/probabilities"],
         style: "cmd_extractor",
-        cmd: "mkdir -p ../../../model && cd ../../../model
+        cmd: "
+            : ${DEEPDIVE_RESULTS_DIR:=\"$DEEPDIVE_APP\"/run/model/results}
+
             # load weights to database
             deepdive create table \(deepdiveInferenceResultVariablesTable | @sh) \\
                 vid:BIGINT \\
                 cid:BIGINT \\
                 prb:'DOUBLE PRECISION' \\
                 #
-            cat probabilities/inference_result.out.text |
-            tr \(" "|@sh) \("\\t"|@sh) | DEEPDIVE_LOAD_FORMAT=tsv \\
-            deepdive load \(deepdiveInferenceResultVariablesTable | @sh) /dev/stdin
+
+            # restore shard ID to the vids
+            for pid in $(seq 0 \($deepdive.sampler.partitions - 1)); do
+                cd $DEEPDIVE_RESULTS_DIR/$pid
+
+                AWK_CMD='{printf \"%s\\t%s\\t%s\\n\", SHARD_BASE + $1, $2, $3}'
+
+                cat inference_result.out.text |
+                awk -v SHARD_BASE=$(($pid << 48)) \"$AWK_CMD\" |
+                DEEPDIVE_LOAD_FORMAT=tsv \\
+                deepdive load \(deepdiveInferenceResultVariablesTable | @sh) /dev/stdin
+            done
+
+            deepdive db analyze \(deepdiveInferenceResultVariablesTable | @sh)
 
             # create a view for each app schema variable
             \([ $deepdive.schema.variables_[] | "

--- a/compiler/compile-config/constants.jq
+++ b/compiler/compile-config/constants.jq
@@ -8,6 +8,7 @@ def deepdiveVariableLabelTruthinessColumn   :  "dd_truthiness"                  
 def deepdiveVariableExpectationColumn       :  "expectation"                    ;
 def deepdiveVariableInternalLabelColumn     :  "dd__label"                      ;
 def deepdiveVariableInternalFrequencyColumn :  "dd__count"                      ;
+def deepdiveVariableInternalPartitionColumn :  "dd__part"                       ;
 def deepdiveGlobalHoldoutTable              :  "dd_graph_variables_holdout"     ;
 def deepdiveGlobalObservationTable          :  "dd_graph_variables_observation" ;
 def deepdiveGlobalWeightsTable              :  "dd_graph_weights"               ;

--- a/compiler/deepdive-default.conf
+++ b/compiler/deepdive-default.conf
@@ -1,8 +1,7 @@
 deepdive {
 
+  sampler.partitions: 1
   sampler.sampler_cmd: "sampler-dw"
-  sampler.sampler_args: "-l 1000 -i 1000 --alpha 0.01 --sample_evidence"
+  sampler.sampler_args: "-l 100 -i 300 --alpha 0.01 --sample_evidence"
 
 }
-
-

--- a/database/db-driver/greenplum/db-assign_sequential_id
+++ b/database/db-driver/greenplum/db-assign_sequential_id
@@ -1,94 +1,73 @@
 #!/usr/bin/env bash
 # db-assign_sequential_id -- Assigns a unique integer to every row for a table using PostgreSQL sequence generator
 # > eval "$(db-parse "$url")"
-# > db-assign_sequential_id TABLE COLUMN BEGIN_ID [INCREMENT] [ORDER_BY...]
+# > db-assign_sequential_id TABLE ID_COLUMN [PART_ID_COLUMN]
 ##
 set -euo pipefail
 
-[[ $# -gt 0 ]] || usage "$0" "Missing TABLE"
-[[ $# -gt 1 ]] || usage "$0" "Missing COLUMN"
-[[ $# -gt 2 ]] || usage "$0" "Missing BEGIN_ID"
-Table=$1 Column=$2 BeginId=$3 Increment=${4:-1} OrderBy=${5:-}
+[[ $# -gt 0 ]] || usage "$0" "Missing TABLE_CSV"
+[[ $# -gt 1 ]] || usage "$0" "Missing ID_COLUMN"
 
-[[ $Increment -ne 0 ]] || usage "$0" "INCREMENT must be non-zero"
+TABLE_CSV=$1 IdColumn=$2 PartColumn=${3:-0}
 
-# Use Greenplum PL/pgSQL and PL/Python UDFs to assign IDs fast
-# See: http://www.postgresql.org/docs/8.2/static/sql-createlanguage.html
-# See: http://www.postgresql.org/docs/8.2/static/plpgsql-overview.html
-# See: http://www.postgresql.org/docs/8.2/static/plpython-funcs.html
-if [[ -z $OrderBy ]] && db-supports_pg_lang "plpgsql" && db-supports_pg_lang "plpythonu"; then
-    db-execute "
-    CREATE OR REPLACE FUNCTION fast_seqassign_init()
-    RETURNS INT AS \$\$
-      if 'cur_id' in SD:
-        SD.pop('cur_id')
-      return 0
-    \$\$ LANGUAGE plpythonu;
 
-    CREATE OR REPLACE FUNCTION fast_seqassign_next(startid BIGINT, increment BIGINT, this_gpsid INT, gpsids INT[], cumulative_cnts BIGINT[], cnts BIGINT[])
+SQL="
+    CREATE OR REPLACE FUNCTION seqassign(partid INT, reset BOOL, pids INT[], offsets BIGINT[])
     RETURNS BIGINT AS \$\$
-      if 'cur_id' not in SD:
-        for gpsid, cumulative_cnt, cnt in zip(gpsids, cumulative_cnts, cnts):
-          if gpsid == this_gpsid:
-            # find the id range using the cumulative count and the size of this segment
-            SD['cur_id'] = startid + increment * (cumulative_cnt - cnt)
-            SD['end_id'] = startid + increment *  cumulative_cnt
-            break
-        if 'cur_id' not in SD:
-          # XXX no segment was found
-          plpy.fatal('No non-empty id range was assigned for segment %s in the initial partition' % str(this_gpsid))
-      # generate fresh id as long as it's within the assigned range
-      id = SD['cur_id']
-      if id != SD['end_id']:
-        SD['cur_id'] += increment
-        return id
-      else:
-        plpy.fatal('Insufficient id range was assigned for segment %s' % str(this_gpsid))
+      if reset:
+        for i, pid in enumerate(pids):
+          SD[pid] = offsets[i]
+        return 0
+
+      x = SD[partid]
+      SD[partid] += 1
+      return x + (partid << 48)
     \$\$ LANGUAGE plpythonu;
 
-    CREATE OR REPLACE FUNCTION fast_seqassign(tname CHARACTER VARYING, cname CHARACTER VARYING, startid BIGINT, increment BIGINT)
-    RETURNS TEXT AS \$\$
-    BEGIN
-      EXECUTE 'CREATE TEMPORARY VIEW dd_tmp_id_ranges_by_gpsid AS
-               SELECT gpsid
-                    , cnt
-                    , SUM(cnt) OVER (ORDER BY gpsid) AS cumulative_cnt
-                 FROM (
-                    SELECT gp_segment_id AS gpsid
-                         , COUNT(1)      AS cnt
-                      FROM ' || QUOTE_IDENT(tname) || '
-                     GROUP BY gpsid
-                     ORDER BY gpsid
-                 ) histogram;';
-      DECLARE
-        gpsids          INT[]    := ARRAY(SELECT gpsid          FROM dd_tmp_id_ranges_by_gpsid ORDER BY gpsid);
-        cumulative_cnts BIGINT[] := ARRAY(SELECT cumulative_cnt FROM dd_tmp_id_ranges_by_gpsid ORDER BY gpsid);
-        cnts            BIGINT[] := ARRAY(SELECT cnt            FROM dd_tmp_id_ranges_by_gpsid ORDER BY gpsid);
-        update_query    TEXT;
-      BEGIN
-        EXECUTE 'SELECT fast_seqassign_init();';
-        update_query := 'UPDATE ' || tname || ' SET ' || cname || ' = fast_seqassign_next(
-            ' || startid || ',
-            ' || increment || ',
-            gp_segment_id,
-            ARRAY[' || ARRAY_TO_STRING(         gpsids, ',')::TEXT || '],
-            ARRAY[' || ARRAY_TO_STRING(cumulative_cnts, ',')::TEXT || '],
-            ARRAY[' || ARRAY_TO_STRING(           cnts, ',')::TEXT || ']
-          );';
-        IF update_query::TEXT IS NOT NULL THEN
-          -- update_query IS NULL for empty tables, hence this guard is necessary
-          EXECUTE update_query;
-        END IF;
-        RETURN 'fast_seqassign done for segments [' || ARRAY_TO_STRING(gpsids, ',') || ']' ||
-               ' with counts [' || ARRAY_TO_STRING(cnts, ',') || ']';
-      END;
-    END;
-    \$\$ LANGUAGE 'plpgsql';
+    SELECT seqassign(1 << 16, true);
 
-    SELECT fast_seqassign('$Table', '$Column', $BeginId, $Increment);
+    CREATE TEMP TABLE idstats(pid INT, tname TEXT, gpsid INT, total BIGINT);
 "
 
-else # if either plpgsql or plpythonu is not available
-    # Delegate to PostgreSQL's way of assigning sequence
-    exec "$(dirname "$0")"/../postgresql/"$(basename "$0")" "$@"
-fi
+
+for table in $(echo $TABLE_CSV | sed "s/,/ /g")
+do
+    SQL="$SQL
+    INSERT INTO idstats
+      SELECT $PartColumn, '$table', gp_segment_id, COUNT(1)
+      FROM $table
+      GROUP BY $PartColumn, gp_segment_id;"
+done
+
+# http://stackoverflow.com/questions/22841206/calculating-cumulative-sum-in-postgresql
+SQL="$SQL
+CREATE TEMP TABLE idstats_rollup AS
+  SELECT pid, gpsid, total, SUM(total) OVER (PARTITION BY pid ORDER BY gpsid) AS cum_total
+  FROM (
+    SELECT pid, gpsid, SUM(total) as total
+    FROM idstats
+    GROUP BY pid, gpsid
+    ORDER BY pid, gpsid
+  ) t;
+
+CREATE TEMP TABLE idstats_bases AS
+  SELECT
+    gpsid,
+    ARRAY_AGG(pid ORDER BY pid) as pids,
+    ARRAY_AGG(cum_total - total ORDER BY pid) as offsets
+  FROM idstats_rollup
+  GROUP BY gpsid;
+
+SELECT seqassign(NULL, true, pids, offsets)
+  FROM idstats_bases
+  WHERE gpsid = gp_segment_id;
+
+"
+
+for table in $(echo $TABLE_CSV | sed "s/,/ /g")
+do
+    SQL="$SQL
+    UPDATE $table SET $IdColumn = seqassign($PartColumn, false, NULL, NULL);"
+done
+
+db-execute "$SQL"

--- a/database/db-driver/greenplum/db-assign_sequential_id
+++ b/database/db-driver/greenplum/db-assign_sequential_id
@@ -10,7 +10,7 @@ set -euo pipefail
 
 TABLE_CSV=$1 IdColumn=$2 PartColumn=${3:-0}
 
-
+# http://gpdb.docs.pivotal.io/4390/ref_guide/extensions/pl_python.html
 SQL="
     CREATE OR REPLACE FUNCTION seqassign(partid INT, reset BOOL, pids INT[], offsets BIGINT[])
     RETURNS BIGINT AS \$\$
@@ -24,9 +24,8 @@ SQL="
       return x + (partid << 48)
     \$\$ LANGUAGE plpythonu;
 
-    SELECT seqassign(1 << 16, true);
-
-    CREATE TEMP TABLE idstats(pid INT, tname TEXT, gpsid INT, total BIGINT);
+    CREATE TEMP TABLE idstats(pid INT, tname TEXT, gpsid INT, total BIGINT)
+      DISTRIBUTED BY (pid);
 "
 
 
@@ -34,12 +33,14 @@ for table in $(echo $TABLE_CSV | sed "s/,/ /g")
 do
     SQL="$SQL
     INSERT INTO idstats
-      SELECT $PartColumn, '$table', gp_segment_id, COUNT(1)
+      SELECT $PartColumn AS pid, '$table', gp_segment_id, COUNT(1)
       FROM $table
-      GROUP BY $PartColumn, gp_segment_id;"
+      GROUP BY pid, gp_segment_id;"
 done
 
 # http://stackoverflow.com/questions/22841206/calculating-cumulative-sum-in-postgresql
+# Use larger table idstats_distributor to ensure stats are processed by all segments.
+# Assuming 1000 rows cover all segments.
 SQL="$SQL
 CREATE TEMP TABLE idstats_rollup AS
   SELECT pid, gpsid, total, SUM(total) OVER (PARTITION BY pid ORDER BY gpsid) AS cum_total
@@ -48,26 +49,36 @@ CREATE TEMP TABLE idstats_rollup AS
     FROM idstats
     GROUP BY pid, gpsid
     ORDER BY pid, gpsid
-  ) t;
+  ) t
+  DISTRIBUTED BY (pid);
 
 CREATE TEMP TABLE idstats_bases AS
   SELECT
     gpsid,
     ARRAY_AGG(pid ORDER BY pid) as pids,
-    ARRAY_AGG(cum_total - total ORDER BY pid) as offsets
+    ARRAY_AGG((cum_total - total)::BIGINT ORDER BY pid) as offsets
   FROM idstats_rollup
-  GROUP BY gpsid;
+  GROUP BY gpsid
+  DISTRIBUTED RANDOMLY;
 
-SELECT seqassign(NULL, true, pids, offsets)
-  FROM idstats_bases
-  WHERE gpsid = gp_segment_id;
+CREATE TEMP TABLE idstats_distributor as
+  SELECT generate_series(1, 1000) id
+  DISTRIBUTED BY (id);
+
+ANALYZE idstats_bases;
+ANALYZE idstats_distributor;
+
+SELECT seqassign(gpsid, true, pids, offsets)
+  FROM idstats_bases a, idstats_distributor b
+  WHERE a.gpsid = b.gp_segment_id;
 
 "
 
 for table in $(echo $TABLE_CSV | sed "s/,/ /g")
 do
     SQL="$SQL
-    UPDATE $table SET $IdColumn = seqassign($PartColumn, false, NULL, NULL);"
+    UPDATE $table SET $IdColumn = seqassign($PartColumn, false, NULL::INT[], NULL::BIGINT[]);"
 done
+
 
 db-execute "$SQL"

--- a/database/db-driver/postgresql-xl/db-assign_sequential_id
+++ b/database/db-driver/postgresql-xl/db-assign_sequential_id
@@ -5,16 +5,15 @@
 ##
 set -euo pipefail
 
+echo "PGXL is not longer supported."
+exit 1
+
 [[ $# -gt 0 ]] || usage "$0" "Missing TABLE"
 [[ $# -gt 1 ]] || usage "$0" "Missing COLUMN"
 [[ $# -gt 2 ]] || usage "$0" "Missing BEGIN_ID"
-Table=$1 Column=$2 BeginId=$3 Increment=${4:-1} OrderBy=${5:-}
+Table=$1 Column=$2 BeginId=$3 Increment=${4:-1}
 
 [[ $Increment -ne 0 ]] || usage "$0" "INCREMENT must be non-zero"
-
-[[ -z $OrderBy ]] ||
-    # Delegate to PostgreSQL's way of assigning sequence when there's an OrderBy
-    exec "$(dirname "$0")"/../postgresql/"$(basename "$0")" "$@"
 
 # Use a PostgreSQL-XL PL/pgSQL UDF to assign IDs fast
 # See: http://www.postgresql.org/docs/9.2/static/sql-createlanguage.html

--- a/database/db-driver/postgresql/db-assign_sequential_id
+++ b/database/db-driver/postgresql/db-assign_sequential_id
@@ -1,60 +1,36 @@
 #!/usr/bin/env bash
 # db-assign_sequential_id -- Assigns a unique integer to every row for a table using PostgreSQL sequence generator
 # > eval "$(db-parse "$url")"
-# > db-assign_sequential_id TABLE COLUMN BEGIN_ID [INCREMENT] [ORDER_BY]
+# > db-assign_sequential_id TABLE ID_COLUMN [PART_ID_COLUMN]
 ##
 set -euo pipefail
 
-[[ $# -gt 0 ]] || usage "$0" "Missing TABLE"
-[[ $# -gt 1 ]] || usage "$0" "Missing COLUMN"
-[[ $# -gt 2 ]] || usage "$0" "Missing BEGIN_ID"
-Table=$1 Column=$2 BeginId=$3 Increment=${4:-1} OrderBy=${5:-}
+[[ $# -gt 0 ]] || usage "$0" "Missing TABLE_CSV"
+[[ $# -gt 1 ]] || usage "$0" "Missing ID_COLUMN"
 
-[[ $Increment -ne 0 ]] || usage "$0" "INCREMENT must be non-zero"
+TABLE_CSV=$1 IdColumn=$2 PartColumn=${3:-0}
 
-if [[ -z $OrderBy ]]; then # no constraint for ordering rows
-    # Use PostgreSQL sequence generator named after the table and column
-    # See: http://www.postgresql.org/docs/current/static/sql-createsequence.html
-    seq="dd_seq_${Table}_${Column}"
-    minMaxValues=
-    if   [[ $Increment -gt 0 && $BeginId -le 0 ]]; then minMaxValues="MINVALUE $BeginId NO MAXVALUE"
-    elif [[ $Increment -lt 0 && $BeginId -ge 0 ]]; then minMaxValues="NO MINVALUE MAXVALUE $BeginId"
-    fi
-    db-execute "
-        DROP SEQUENCE IF EXISTS $seq CASCADE;
-        CREATE TEMPORARY SEQUENCE $seq INCREMENT BY $Increment $minMaxValues START $BeginId NO CYCLE;
 
-        UPDATE $Table SET $Column = nextval('$seq');
-    "
+SQL="
+    CREATE OR REPLACE FUNCTION seqassign(partid INT, reset BOOL)
+    RETURNS BIGINT AS \$\$
+      if reset:
+        for pid in range(partid):
+          SD[pid] = 0
+        return 0
 
-else # ORDER BY given COLUMNs
+      x = SD[partid]
+      SD[partid] += 1
+      return x + (partid << 48)
+    \$\$ LANGUAGE plpythonu;
 
-    # find existing columns in the target table
-    eval "columns=(
-    $(db-execute '\d '"$Table" --tuples-only --no-align --field-separator=$'\t' | cut -f1 # TODO | escape4sh
-    )
-    )"
-    set --
-    for col in "${columns[@]}"; do
-        if [[ $col = $Column ]]; then
-            # use ROW_NUMBER() OVER ORDER BY with given clause
-            set -- "$@" "$BeginId + $Increment * ((ROW_NUMBER() OVER (ORDER BY $OrderBy)) - 1) AS \"${col//\"/\"\"}\""
-        else
-            set -- "$@" "\"${col//\"/\"\"}\""
-        fi
-    done
+    SELECT seqassign(1 << 16, true);
+"
 
-    # create a temporary table like the original one
-    newTable="dd_tmpseq_$Table"
-    db-create-table-like "$newTable" "$Table"
+for table in $(echo $TABLE_CSV | sed "s/,/ /g")
+do
+    SQL="$SQL
+    UPDATE $table SET $IdColumn = seqassign($PartColumn, false);"
+done
 
-    # copy rows into the temporary and replace the target table
-    columnsToProject=$(printf "%s, " "$@")
-    columnsToProject=${columnsToProject%, }  # dropping last comma
-    db-execute "
-        INSERT INTO $newTable SELECT $columnsToProject FROM $Table;
-        DROP TABLE $Table;
-        ALTER TABLE $newTable RENAME TO $Table;
-    "
-
-fi
+db-execute "$SQL"

--- a/database/db-driver/postgresql/db-init
+++ b/database/db-driver/postgresql/db-init
@@ -5,11 +5,4 @@
 ##
 set -eu
 
-if [[ $# -gt 0 ]]; then
-    createdb "$DBNAME" || true >/dev/null
-else
-    {
-    dropdb "$DBNAME" || true
-    createdb "$DBNAME"
-    } >/dev/null
-fi
+createdb "$DBNAME" || true >/dev/null

--- a/doc/ops-model.md
+++ b/doc/ops-model.md
@@ -84,7 +84,7 @@ deepdive model ground
 The above can be viewed as a shorthand for executing the following [built-in processes](ops-execution.md#built-in-data-flow-nodes):
 
 ```bash
-deepdive redo process/grounding/variable_id_partition process/grounding/combine_factorgraph
+deepdive redo process/grounding/variable_assign_id process/grounding/combine_factorgraph
 ```
 
 Grounding generates a set of files for each variable and factor under `run/model/grounding/`.

--- a/examples/census/app.ddlog
+++ b/examples/census/app.ddlog
@@ -20,6 +20,7 @@ adult(
 
 
 rich? (
+    @partition
     id int
 ).
 

--- a/examples/census/deepdive.conf
+++ b/examples/census/deepdive.conf
@@ -1,4 +1,5 @@
 deepdive {
   calibration.holdout_fraction: 0.25
-  sampler.sampler_args: "-l 1000 -i 1000 --sample_evidence"
+  sampler.partitions: 3
+  sampler.sampler_args: "-l 100 -i 100 --sample_evidence"
 }

--- a/examples/chunking/deepdive.conf
+++ b/examples/chunking/deepdive.conf
@@ -5,5 +5,5 @@ deepdive.calibration.holdout_query: """
     FROM dd_variables_chunk
     WHERE word_id > 220663
 """
-
+#deepdive.sampler.sampler_cmd: "numbskull"
 deepdive.sampler.sampler_args: "-l 100 -i 100 --sample_evidence"

--- a/examples/chunking/input/init_words.sh
+++ b/examples/chunking/input/init_words.sh
@@ -3,7 +3,7 @@
 set -eu
 cd "$(dirname "$0")"
 
-if [[ -n ${SUBSAMPLE_NUM_WORDS_TRAIN:-} && -n ${SUBSAMPLE_NUM_WORDS_TEST:-} ]]; then
+if [[ -n ${SUBSAMPLE_NUM_WORDS_TRAIN:-1000} && -n ${SUBSAMPLE_NUM_WORDS_TEST:-1000} ]]; then
     head -n ${SUBSAMPLE_NUM_WORDS_TRAIN} ./train_null_terminated.txt
     head -n ${SUBSAMPLE_NUM_WORDS_TEST}   ./test_null_terminated.txt
 else

--- a/inference/deepdive-model
+++ b/inference/deepdive-model
@@ -143,7 +143,7 @@ case $Command in
                             weights)
                                 # TODO load into a unique table, then create a view with the following name
                                 weightTableName=dd_graph_weights_reuse
-                                weightsReuseFlag="$DEEPDIVE_APP"/run/model/grounding/factor/weights.reuse
+                                weightsReuseFlag="$DEEPDIVE_APP"/run/model/grounding/weights.reuse
                                 deepdive create table "$weightTableName" "description:TEXT" "weight:DOUBLE PRECISION"
                                 rm -f "$weightsReuseFlag"
                                 # check if the kept weights are compatible
@@ -184,11 +184,11 @@ case $Command in
                 cd "$DEEPDIVE_APP"
                 case $What in
                     factorgraph)
-                        deepdive-mark todo process/grounding/variable_id_partition
+                        deepdive-mark todo process/grounding/variable_assign_id
                         rm -rfv run/model/{grounding,factorgraph{,.done}}
                         ;;
                     weights)
-                        rm -fv run/model/grounding/factor/weights.reuse
+                        rm -fv run/model/grounding/weights.reuse
                         deepdive-mark todo $(deepdive plan 2>&1 | grep '/dump_weights$')
                         ;;
                 esac

--- a/test/postgresql/db-assign_sequential_id.bats
+++ b/test/postgresql/db-assign_sequential_id.bats
@@ -1,5 +1,4 @@
 #!/usr/bin/env bats
-# Tests for biased coin example
 
 . "$BATS_TEST_DIRNAME"/env.sh >&2
 
@@ -11,56 +10,37 @@ setup() {
     # make sure it fails on inssuficient arguments
     ! deepdive db assign_sequential_id              || false
     ! deepdive db assign_sequential_id table        || false
-    ! deepdive db assign_sequential_id table column || false
 }
 
 @test "$DBVARIANT db-assign_sequential_id works" {
     num_failures=0
-    for numrows in 0 1 1000; do
+    for numrows in 0 1 37 1000; do
         # set up a table
         echo "Setting up a table of $numrows rows"
         deepdive sql "DROP TABLE foo CASCADE;" || true
         deepdive sql "CREATE TABLE foo(x TEXT, y BIGINT);"
         seq $numrows | sed 's/.*/INSERT INTO foo(x) VALUES (&);/' | deepdive sql
 
-        for increment in 123 10 1; do
-            for begin in 12345 -678 1 0; do
-                end=$(($begin + ($numrows - 1) * $increment))
-                echo "Testing assign_sequential_id from $begin to $end by increment $increment ($numrows rows)"
-                # assign sequence
-                deepdive db assign_sequential_id foo y $begin $increment || let ++num_failures
-                # and compare with what's expected
-                diff -u <(seq $begin $increment $end) <(deepdive sql eval "SELECT y FROM foo ORDER BY y") || let ++num_failures
-            done
-        done
+        begin=0
+        end=$(($numrows - 1))
+        echo "Testing assign_sequential_id without partition column ($numrows rows)"
+        # assign sequence
+        deepdive db assign_sequential_id foo y || let ++num_failures
+        # and compare with what's expected
+        diff -u <(seq $begin $end) <(deepdive sql eval "SELECT y FROM foo ORDER BY y") || let ++num_failures
 
-        echo "Testing if zero increment is rejected"
-        ! deepdive db assign_sequential_id foo y $begin 0 || let ++num_failures
+        echo "Testing assign_sequential_id with partition column ($numrows rows)"
+        deepdive db assign_sequential_id foo y "x::int % 6" || let ++num_failures
+        # verify num of IDs in partition 0
+        diff -u <(echo $(($numrows / 6))) <(deepdive sql eval "SELECT COUNT(1) FROM foo WHERE y <= $numrows") || let ++num_failures
+
+        # verify num of partitions
+        if [ $numrows -gt 6 ]; then
+            diff -u <(echo 6) <(deepdive sql eval "SELECT COUNT(DISTINCT y >> 48) FROM foo") || let ++num_failures
+        fi
     done
     [[ $num_failures -eq 0 ]] || {
         echo "Failed $num_failures checks"
         false
     }
-}
-
-@test "$DBVARIANT db-assign_sequential_id works with ORDER_BY constraint" {
-    numrows=1000
-    echo "populating table foo..."
-    deepdive sql "DROP TABLE foo CASCADE;" || true
-    deepdive sql "CREATE TABLE foo(x TEXT, y BIGINT, z DOUBLE PRECISION);"
-    seq $numrows | sed 's/.*/INSERT INTO foo(x) VALUES (&);/' | deepdive sql >/dev/null
-
-    # set a column to random numbers
-    echo "randomizing column z..."
-    deepdive sql "UPDATE foo SET z = RANDOM()"
-
-    # assign id according to the order of the randomized column
-    echo "db-assign_sequential_id..."
-    deepdive db assign_sequential_id foo y 1 1 "z"
-
-    # check if the order is correct
-    echo "checking order..."
-    incorrect_rows=$(deepdive sql eval "SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY z) AS rn FROM foo) bar WHERE rn != y" format=tsv)
-    echo "$incorrect_rows"
-    [[ -z $incorrect_rows ]]
 }


### PR DESCRIPTION
Fixes #478 and getting ready for scale-out (with numbskull).

The factor graph of a typical DD app consists of many connected components (e.g., one per doc) that each fits in memory. The entire FG however sometimes is (much) larger than one box's memory size. This change enables a user to specify whether and how the FG should be sharded so that DD can process a 100TB graph with one box with 16GB of RAM, or on a cluster in the near future (say with numbskull).

To use sharding, only two lines of change is needed (see `examples/census`):
1. In `app.ddlog`, annotate partition key columns of a variable relation with `@partition`.
2. In `deepdive.conf`, specify `deepdive.sampler.partitions`.

With these changes, this is what DD does that's different from before:
1. Before, the var IDs take range `[0...$num_vars)`. With sharding, each shard `i` has its own var ID space `[0..$num_vars_for_shard_i)`. Internally, the `dd_variables_...` table has a new field `dd__part` taking value `i`, and the var ID takes value `i << 48 + var_id_for_shard_i`. The ID assignment code has been revamped and actually simplified to support this multi-namespace change. Grounding SQL is the same as before (i.e., not broken down for each shard), with the factor tables taking the multi-namespace var IDs.
2. We assume that no factor ever crosses multiple user-specified partition keys (with `@partition`). The FG's variables and factors are hence cleanly partitioned. But each shard shares all the weights. For now, we assume that all weights fit in memory. When dumping the FG into the DW binary format, we dump each shard in turn, in the process clearing the first 16 bit of the 64-bit var IDs (for both var dump and factor dump) so that the sampler doesn't need to accommodate. After each shard's inference, when loading the marginal probabilities into the DB, we add back the first 16 bit shard ID.
3. If `deepdive.sampler.partitions = 1` (which is default), the learning / inference flow is same as before. If `deepdive.sampler.partitions > 1`, right now, we simply run learning on each shard in turn (shard `k+1` starting with weights from shard `k`), and then run inference on each shard in turn (using weights produced by the last shard during learning). We defer systematic multi-shard learning algo design to the near future (numbskull in particular).
4. The new ID assignment code now requires the DB to have `plpythonu` enabled.

I'm going to do more testing in the next few days. In the meantime, would like to hear everyone's feedback about the design and details.