### PR TITLE
Version conda builds using git

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: deepdive
-  version: "0.8"
+  version: {{ GIT_DESCRIBE_TAG|replace("v","") }}
 
 source:
   git_url: ../
@@ -8,7 +8,7 @@ source:
 build:
   script_env:
     - USER
-  number: 1
+  number: {{ GIT_DESCRIBE_NUMBER|int }}
 
 test:
   files:


### PR DESCRIPTION
We'd like to build conda packages without having to specify the version number manually. The version of the conda package should always correspond to the version according to git.

Use git to version the conda package, so that:

1. The most recent tag on the branch being built is used as the version number, and
2. The number of commits since that tag on this branch is used as the build number.

(2) means that we need to stop rebasing non-local branches. Instead, use `git merge`.

Note that the most recent tag on `master` is `UNSTABLE` which isn't a version number:

```
$ git describe --abbrev=0 --tag
UNSTABLE
```

Once this is merged in, we should tag the merge commit with a new version (v0.8.1?) so that the resulting package has a name that makes sense.