### PR TITLE
Use View for factor tables in Grounding

### DIFF
--- a/compiler/compile-config/compile-config-2.01-grounding
+++ b/compiler/compile-config/compile-config-2.01-grounding
@@ -339,7 +339,7 @@ def factorWeightDescriptionSqlExpr:
         style: "cmd_extractor", cmd: "
 
             # materialize factors using user input_query that pulls in assigned ids to involved variables
-            deepdive create table \(.factorsTable | @sh) as \(
+            deepdive create view \(.factorsTable | @sh) as \(
                 # Not using DISTINCT: User decides if they want to have duplicate factors
                 { SELECT:
                     [ ( .function_.variables[] | { table: "F", column: .columnId } )


### PR DESCRIPTION
In many applications, factor tables are huge tables unnested from compact original representations. This change to use views instead of materializing them is measured to save 30--40% of overall grounding time in some application.