### PR TITLE
Support for DimmWitted's parallel factor graph loading

### DIFF
--- a/compiler/compile-config/compile-config-2.01-grounding
+++ b/compiler/compile-config/compile-config-2.01-grounding
@@ -663,16 +663,14 @@ def factorWeightDescriptionSqlExpr:
                 mkdir -p {variables,domains}/\"$v\"
                 find \"$DEEPDIVE_GROUNDING_DIR\"/variable/\"$v\" \\
                     -name \"variables.$pid.part-*.bin.bz2\" -exec ln -sfnv -t variables/\"$v\"/ {} + \\
-                    -o \\
-                    -name \"domains.$pid.part-*.bin.bz2\" -exec ln -sfnv -t   domains/\"$v\"/ {} + \\
+                 -o -name   \"domains.$pid.part-*.bin.bz2\" -exec ln -sfnv -t   domains/\"$v\"/ {} + \\
                     #
             done
             for f in \($factorNames); do
                 mkdir -p {factors,weights}/\"$f\"
                 find \"$DEEPDIVE_GROUNDING_DIR\"/factor/\"$f\" \\
                     -name \"factors.$pid.part-*.bin.bz2\" -exec ln -sfnv -t factors/\"$f\"/ {} + \\
-                    -o \\
-                    -name 'weights.part-*.bin.bz2' -exec ln -sfnv -t weights/\"$f\"/ {} + \\
+                 -o -name      \"weights.part-*.bin.bz2\" -exec ln -sfnv -t weights/\"$f\"/ {} + \\
                     #
             done
 
@@ -690,6 +688,7 @@ def factorWeightDescriptionSqlExpr:
                 counts+=($(find \($factorNames) -name \"nedges.$pid.part-*\"   -exec cat {} + | sumup))
                 (IFS=,; echo \"${counts[*]}\")
                 # second line with file paths
+                # FIXME second line and beyond are no longer used, remove
                 paths=(\"$DEEPDIVE_FACTORGRAPH_DIR\"/{weights,variables,factors,edges,domains})
                 (IFS=,; echo \"${paths[*]}\")
             } > \"$DEEPDIVE_FACTORGRAPH_DIR/$pid/meta\"

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -171,7 +171,7 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
 
                 AWK_CMD='{printf \"%s\\t%s\\t%s\\n\", SHARD_BASE + $1, $2, $3}'
 
-                cat inference_result.out.text |
+                cat \"$results_dir\"/inference_result.out.text |
                 awk -v SHARD_BASE=$(($pid << 48)) \"$AWK_CMD\" |
                 DEEPDIVE_LOAD_FORMAT=tsv \\
                 deepdive load \(deepdiveInferenceResultVariablesTable | @sh) /dev/stdin

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -123,31 +123,30 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
         : ${DEEPDIVE_FACTORGRAPH_DIR:=\"$DEEPDIVE_APP\"/run/model/factorgraph}
         export DEEPDIVE_NUM_PROCESSES
 
-        # need to run inference only if learning step was deferred because there are multiple shards
-        \(if $deepdive.sampler.partitions > 1 then "
-            for pid in $(seq 0 \($deepdive.sampler.partitions - 1)); do
-                results_dir=\"$DEEPDIVE_RESULTS_DIR\"/$pid
-                mkdir -p \"$results_dir\"
-                fg_dir=\"$DEEPDIVE_FACTORGRAPH_DIR\"/$pid
-                [[ -d \"$fg_dir\" ]] || error \"$fg_dir: No factorgraph found\"
-                cd \"$fg_dir\"
+        # need to run inference if learning step was deferred because there are multiple shards
+        # or because different weights are used
+        for pid in $(seq 0 \($deepdive.sampler.partitions - 1)); do
+            results_dir=\"$DEEPDIVE_RESULTS_DIR\"/$pid
+            mkdir -p \"$results_dir\"
+            fg_dir=\"$DEEPDIVE_FACTORGRAPH_DIR\"/$pid
+            [[ -d \"$fg_dir\" ]] || error \"$fg_dir: No factorgraph found\"
+            cd \"$fg_dir\"
 
-                # run sampler for inference with given weights without learning
-                ln -sfn ../learned_weights weights.to_infer
-                run-sampler \\
-                        weights=weights.to_infer \\
-                        results_dir=\"$results_dir\" \\
-                    -- \\
-                        \($deepdive.sampler.sampler_cmd | @sh) \\
-                        \($deepdive.sampler.sampler_args // "") \\
-                        -l 0 \\
-                        #
-            done
+            # skip if inference was already done
+            ! [[ -e \"$results_dir\"/inference_result.out.text ]] || continue
 
-        " else "
-            # TODO skip only if there's already a fresh inference_result.out.text
-            echo Skipping process/model/inference because it was inlined in process/model/learning
-        " end)
+            # run sampler for inference with given weights without learning
+            ln -sfn ../learned_weights weights.to_infer
+
+            run-sampler \\
+                    weights=weights.to_infer \\
+                    results_dir=\"$results_dir\" \\
+                -- \\
+                    \($deepdive.sampler.sampler_cmd | @sh) \\
+                    \($deepdive.sampler.sampler_args // "") \\
+                    -l 0 \\
+                    #
+        done
         "
     },
 
@@ -167,11 +166,11 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
 
             # restore shard ID to the vids
             for pid in $(seq 0 \($deepdive.sampler.partitions - 1)); do
-                cd $DEEPDIVE_RESULTS_DIR/$pid
+                cd \"$DEEPDIVE_RESULTS_DIR\"/$pid
 
                 AWK_CMD='{printf \"%s\\t%s\\t%s\\n\", SHARD_BASE + $1, $2, $3}'
 
-                cat \"$results_dir\"/inference_result.out.text |
+                cat inference_result.out.text |
                 awk -v SHARD_BASE=$(($pid << 48)) \"$AWK_CMD\" |
                 DEEPDIVE_LOAD_FORMAT=tsv \\
                 deepdive load \(deepdiveInferenceResultVariablesTable | @sh) /dev/stdin

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -83,11 +83,11 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                 wid:BIGINT:'PRIMARY KEY' \\
                 weight:'DOUBLE PRECISION' \\
                 #
-            cat inference_result.out.weights.text |
+            cat \"$results_dir\"/inference_result.out.weights.text |
             tr \(" "|@sh) \("\\t"|@sh) |
             deepdive load \(deepdiveInferenceResultWeightsTable | @sh) /dev/stdin
             deepdive db analyze \(deepdiveInferenceResultWeightsTable | @sh)
-            mv -f inference_result.out.weights.text inference_result.out.weights.text.learned
+            mv -f \"$results_dir\"/inference_result.out.weights.text \"$results_dir\"/inference_result.out.weights.text.learned
 
             \(if $deepdive.sampler.partitions > 1 then "
                 # dump weights back out for next-shard learning or inference step

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -21,17 +21,15 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
         : ${DEEPDIVE_NUM_PROCESSES:=$(nproc --ignore=1)}
         : ${DEEPDIVE_RESULTS_DIR:=\"$DEEPDIVE_APP\"/run/model/results}
         : ${DEEPDIVE_FACTORGRAPH_DIR:=\"$DEEPDIVE_APP\"/run/model/factorgraph}
+        export DEEPDIVE_NUM_PROCESSES
 
-        flatten() { find -L \"$@\" -type f -size +0 -exec pbzip2 -c -d -k {} +; }
-
+        # run inference engine for learning and inference on each shard
         for pid in $(seq 0 \($deepdive.sampler.partitions - 1)); do
             results_dir=\"$DEEPDIVE_RESULTS_DIR\"/$pid
             mkdir -p \"$results_dir\"
             fg_dir=\"$DEEPDIVE_FACTORGRAPH_DIR\"/$pid
             [[ -d \"$fg_dir\" ]] || error \"$fg_dir: No factorgraph found\"
             cd \"$fg_dir\"
-
-            # run inference engine for learning and inference
 
             # decide which set of weights to start learning from
             if [[ $pid -eq 0 ]]; then
@@ -42,37 +40,16 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                 weights_hot=../$(($pid - 1))/weights.learned
             fi
             [[ $weights_hot -ef weights.to_learn ]] || ln -sfn $weights_hot weights.to_learn
-            weights=weights.to_learn
 
-            # if there are multiple shards, we suppress inference (-i 0)
-
-            \(if $deepdive.sampler.sampler_cmd == "numbskull" then "
-                mkdir -p ./flat
-                head -n 1 ./meta        >./flat/graph.meta
-                # TODO: save disk space
-                flatten ./variables/    >./flat/graph.variables
-                flatten ./factors/      >./flat/graph.factors
-                flatten ./$weights/     >./flat/graph.weights
-                flatten ./domains/      >./flat/graph.domains
-                numbskull ./flat \\
-                    --output_dir \"$results_dir\" \\
-                    --threads $DEEPDIVE_NUM_PROCESSES \\
+            # if there are multiple shards, we defer inference (-i 0)
+            run-sampler \\
+                    weights=weights.to_learn \\
+                    results_dir=\"$results_dir\" \\
+                -- \\
+                    \($deepdive.sampler.sampler_cmd | @sh) \\
                     \($deepdive.sampler.sampler_args // "") \\
                     \(if $deepdive.sampler.partitions > 1 then "-i 0" else "" end) \\
                     #
-            " else "
-                \($deepdive.sampler.sampler_cmd) gibbs      \\
-                    --variables <(flatten ./variables/)     \\
-                    --domains   <(flatten ./domains/  )     \\
-                    --factors   <(flatten ./factors/  )     \\
-                    --weights   <(flatten ./$weights/ )     \\
-                    --fg_meta   ./meta                      \\
-                    --outputFile \"$results_dir\"           \\
-                    --n_threads $DEEPDIVE_NUM_PROCESSES     \\
-                    \($deepdive.sampler.sampler_args // "") \\
-                    \(if $deepdive.sampler.partitions > 1 then "-i 0" else "" end) \\
-                    #
-            " end)
 
             # TODO maybe this database interaction for the weights after
             # learning each shard is unnecessary if we have the sampler checkpoint
@@ -144,8 +121,7 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
         : ${DEEPDIVE_NUM_PROCESSES:=$(nproc --ignore=1)}
         : ${DEEPDIVE_RESULTS_DIR:=\"$DEEPDIVE_APP\"/run/model/results}
         : ${DEEPDIVE_FACTORGRAPH_DIR:=\"$DEEPDIVE_APP\"/run/model/factorgraph}
-
-        flatten() { find -L \"$@\" -type f -size +0 -exec pbzip2 -c -d -k {} +; }
+        export DEEPDIVE_NUM_PROCESSES
 
         # need to run inference only if learning step was deferred because there are multiple shards
         \(if $deepdive.sampler.partitions > 1 then "
@@ -158,40 +134,18 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
 
                 # run sampler for inference with given weights without learning
                 ln -sfn ../learned_weights weights.to_infer
-                weights=weights.to_infer
-
-                \(if $deepdive.sampler.sampler_cmd == "numbskull" then "
-                    mkdir -p ./flat
-                    if [ ./meta -nt ./flat/graph.meta ]; then
-                        head -n 1 ./meta     >./flat/graph.meta
-                        flatten ./variables/ >./flat/graph.variables
-                        flatten ./factors/   >./flat/graph.factors
-                        flatten ./domains/   >./flat/graph.domains
-                    fi
-                    flatten ./$weights/ >./flat/graph.weights
-                    numbskull ./flat \\
-                        --output_dir \"$results_dir\" \\
-                        --threads $DEEPDIVE_NUM_PROCESSES \\
+                run-sampler \\
+                        weights=weights.to_infer \\
+                        results_dir=\"$results_dir\" \\
+                    -- \\
+                        \($deepdive.sampler.sampler_cmd | @sh) \\
                         \($deepdive.sampler.sampler_args // "") \\
                         -l 0 \\
                         #
-                " else "
-                    \($deepdive.sampler.sampler_cmd) gibbs      \\
-                        --variables <(flatten ./variables/)     \\
-                        --domains   <(flatten ./domains/  )     \\
-                        --factors   <(flatten ./factors/  )     \\
-                        --weights   <(flatten ./$weights/ )     \\
-                        --fg_meta   ./meta                      \\
-                        --outputFile \"$results_dir\"           \\
-                        --n_threads $DEEPDIVE_NUM_PROCESSES     \\
-                        \($deepdive.sampler.sampler_args // "") \\
-                        -l 0 \\
-                        #
-                " end)
-
             done
 
         " else "
+            # TODO skip only if there's already a fresh inference_result.out.text
             echo Skipping process/model/inference because it was inlined in process/model/learning
         " end)
         "

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -25,12 +25,11 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
         flatten() { find -L \"$@\" -type f -size +0 -exec pbzip2 -c -d -k {} +; }
 
         for pid in $(seq 0 \($deepdive.sampler.partitions - 1)); do
-            mkdir -p $DEEPDIVE_RESULTS_DIR/$pid
-            cd $DEEPDIVE_RESULTS_DIR/$pid
-
-            FGDIR=$DEEPDIVE_FACTORGRAPH_DIR/$pid
-
-            [ -d $FGDIR ] || error \"No factorgraph found\"
+            results_dir=\"$DEEPDIVE_RESULTS_DIR\"/$pid
+            mkdir -p \"$results_dir\"
+            fg_dir=\"$DEEPDIVE_FACTORGRAPH_DIR\"/$pid
+            [[ -d \"$fg_dir\" ]] || error \"$fg_dir: No factorgraph found\"
+            cd \"$fg_dir\"
 
             # run inference engine for learning and inference
 
@@ -44,29 +43,28 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
             # if there are multiple shards, we suppress inference (-i 0)
 
             \(if $deepdive.sampler.sampler_cmd == "numbskull" then "
-                mkdir -p $FGDIR/flat
-                head -n 1 $FGDIR/meta > $FGDIR/flat/graph.meta
+                mkdir -p ./flat
+                head -n 1 ./meta        >./flat/graph.meta
                 # TODO: save disk space
-                flatten $FGDIR/variables > $FGDIR/flat/graph.variables
-                flatten $FGDIR/factors > $FGDIR/flat/graph.factors
-                flatten $FGDIR/$WEIGHT_DIR > $FGDIR/flat/graph.weights
-                flatten $FGDIR/domains > $FGDIR/flat/graph.domains
-                numbskull $FGDIR/flat \\
-                    --output_dir . \\
+                flatten ./variables     >./flat/graph.variables
+                flatten ./factors       >./flat/graph.factors
+                flatten ./$WEIGHT_DIR   >./flat/graph.weights
+                flatten ./domains       >./flat/graph.domains
+                numbskull ./flat \\
+                    --output_dir \"$results_dir\" \\
                     --threads $DEEPDIVE_NUM_PROCESSES \\
                     \($deepdive.sampler.sampler_args // "") \\
                     \(if $deepdive.sampler.partitions > 1 then "-i 0" else "" end) \\
                     #
             " else "
-                \($deepdive.sampler.sampler_cmd) \\
-                    gibbs \\
-                    --variables <(flatten $FGDIR/variables) \\
-                    --domains <(flatten $FGDIR/domains) \\
-                    --factors <(flatten $FGDIR/factors) \\
-                    --weights <(flatten $FGDIR/$WEIGHT_DIR) \\
-                    --fg_meta $FGDIR/meta \\
-                    --outputFile . \\
-                    --n_threads $DEEPDIVE_NUM_PROCESSES \\
+                \($deepdive.sampler.sampler_cmd) gibbs      \\
+                    --variables <(flatten ./variables  )    \\
+                    --domains   <(flatten ./domains    )    \\
+                    --factors   <(flatten ./factors    )    \\
+                    --weights   <(flatten ./$WEIGHT_DIR)    \\
+                    --fg_meta   ./meta                      \\
+                    --outputFile \"$results_dir\"           \\
+                    --n_threads $DEEPDIVE_NUM_PROCESSES     \\
                     \($deepdive.sampler.sampler_args // "") \\
                     \(if $deepdive.sampler.partitions > 1 then "-i 0" else "" end) \\
                     #
@@ -81,18 +79,18 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
             tr \(" "|@sh) \("\\t"|@sh) |
             deepdive load \(deepdiveInferenceResultWeightsTable | @sh) /dev/stdin
             deepdive db analyze \(deepdiveInferenceResultWeightsTable | @sh)
-            mv inference_result.out.weights.text inference_result.out.weights.text.learned
+            mv -f inference_result.out.weights.text inference_result.out.weights.text.learned
 
             \(if $deepdive.sampler.partitions > 1 then "
                 # dump weights back out for next-shard learning or inference step
-                if [ $pid -lt \($deepdive.sampler.partitions - 1) ]; then
+                if [[ $pid -lt \($deepdive.sampler.partitions - 1) ]]; then
                     # not last shard: dump for next-shard learning
-                    export TARGET_WEIGHT_DIR=$DEEPDIVE_FACTORGRAPH_DIR/$(($pid+1))/weights_hot
+                    export TARGET_WEIGHT_DIR=\"$DEEPDIVE_FACTORGRAPH_DIR\"/$(($pid+1))/weights_hot
                 else
-                    export TARGET_WEIGHT_DIR=$DEEPDIVE_FACTORGRAPH_DIR/learned_weights
+                    export TARGET_WEIGHT_DIR=\"$DEEPDIVE_FACTORGRAPH_DIR\"/learned_weights
                 fi
 
-                mkdir -p $TARGET_WEIGHT_DIR
+                mkdir -p \"$TARGET_WEIGHT_DIR\"
                 deepdive compute execute \\
                     input_sql=\(
                         { SELECT:
@@ -108,7 +106,8 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                                 }
                         } | asSql | asPrettySqlArg) \\
                     command=\("
-                        sampler-dw text2bin weight /dev/stdin /dev/stdout /dev/null | pbzip2 >$TARGET_WEIGHT_DIR/weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
+                        sampler-dw text2bin weight /dev/stdin /dev/stdout /dev/null |
+                        pbzip2 >\"$TARGET_WEIGHT_DIR\"/weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
                     " | @sh) \\
                     output_relation=
 
@@ -146,43 +145,39 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
         # need to run inference only if learning step was deferred because there are multiple shards
         \(if $deepdive.sampler.partitions > 1 then "
             for pid in $(seq 0 \($deepdive.sampler.partitions - 1)); do
+                results_dir=\"$DEEPDIVE_RESULTS_DIR\"/$pid
+                mkdir -p \"$results_dir\"
+                fg_dir=\"$DEEPDIVE_FACTORGRAPH_DIR\"/$pid
+                [[ -d \"$fg_dir\" ]] || error \"$fg_dir: No factorgraph found\"
+                cd \"$fg_dir\"
 
-                mkdir -p $DEEPDIVE_RESULTS_DIR/$pid
-                cd $DEEPDIVE_RESULTS_DIR/$pid
-
-                FGDIR=$DEEPDIVE_FACTORGRAPH_DIR/$pid
-
-                [ -d $FGDIR ] || error \"No factorgraph found\"
-
-                # XXX this skipping may cause confusion
                 # run sampler for inference with given weights without learning
-                LEARNED_WEIGHTS=$DEEPDIVE_FACTORGRAPH_DIR/learned_weights
+                LEARNED_WEIGHTS=\"$DEEPDIVE_FACTORGRAPH_DIR\"/learned_weights
 
                 \(if $deepdive.sampler.sampler_cmd == "numbskull" then "
-                    mkdir -p $FGDIR/flat
-                    if [ $FGDIR/meta -nt $FGDIR/flat/graph.meta ]; then
-                        head -n 1 $FGDIR/meta > $FGDIR/flat/graph.meta
-                        flatten $FGDIR/variables > $FGDIR/flat/graph.variables
-                        flatten $FGDIR/factors > $FGDIR/flat/graph.factors
-                        flatten $FGDIR/domains > $FGDIR/flat/graph.domains
+                    mkdir -p ./flat
+                    if [ ./meta -nt ./flat/graph.meta ]; then
+                        head -n 1 ./meta    >./flat/graph.meta
+                        flatten ./variables >./flat/graph.variables
+                        flatten ./factors   >./flat/graph.factors
+                        flatten ./domains   >./flat/graph.domains
                     fi
-                    flatten $LEARNED_WEIGHTS > $FGDIR/flat/graph.weights
-                    numbskull $FGDIR/flat \\
-                        --output_dir . \\
+                    flatten \"$LEARNED_WEIGHTS\" >./flat/graph.weights
+                    numbskull ./flat \\
+                        --output_dir \"$results_dir\" \\
                         --threads $DEEPDIVE_NUM_PROCESSES \\
                         \($deepdive.sampler.sampler_args // "") \\
                         -l 0 \\
                         #
                 " else "
-                    \($deepdive.sampler.sampler_cmd) \\
-                        gibbs \\
-                        --variables <(flatten $FGDIR/variables) \\
-                        --domains <(flatten $FGDIR/domains) \\
-                        --factors <(flatten $FGDIR/factors) \\
-                        --weights <(flatten $LEARNED_WEIGHTS) \\
-                        --fg_meta $FGDIR/meta \\
-                        --outputFile . \\
-                        --n_threads $DEEPDIVE_NUM_PROCESSES \\
+                    \($deepdive.sampler.sampler_cmd) gibbs      \\
+                        --variables <(flatten ./variables)      \\
+                        --domains   <(flatten ./domains)        \\
+                        --factors   <(flatten ./factors)        \\
+                        --weights   <(flatten \"$LEARNED_WEIGHTS\") \\
+                        --fg_meta   ./meta                      \\
+                        --outputFile \"$results_dir\"           \\
+                        --n_threads $DEEPDIVE_NUM_PROCESSES     \\
                         \($deepdive.sampler.sampler_args // "") \\
                         -l 0 \\
                         #

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -33,12 +33,16 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
 
             # run inference engine for learning and inference
 
-            if [ $pid -gt 0 ]; then
-                # use weights learned from previous shard
-                WEIGHT_DIR=weights_hot
+            # decide which set of weights to start learning from
+            if [[ $pid -eq 0 ]]; then
+                # start from cold weights for the first shard
+                weights_hot=weights
             else
-                WEIGHT_DIR=weights
+                # use hot weights learned from previous shard
+                weights_hot=../$(($pid - 1))/weights.learned
             fi
+            [[ $weights_hot -ef weights.to_learn ]] || ln -sfn $weights_hot weights.to_learn
+            weights=weights.to_learn
 
             # if there are multiple shards, we suppress inference (-i 0)
 
@@ -46,10 +50,10 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                 mkdir -p ./flat
                 head -n 1 ./meta        >./flat/graph.meta
                 # TODO: save disk space
-                flatten ./variables     >./flat/graph.variables
-                flatten ./factors       >./flat/graph.factors
-                flatten ./$WEIGHT_DIR   >./flat/graph.weights
-                flatten ./domains       >./flat/graph.domains
+                flatten ./variables/    >./flat/graph.variables
+                flatten ./factors/      >./flat/graph.factors
+                flatten ./$weights/     >./flat/graph.weights
+                flatten ./domains/      >./flat/graph.domains
                 numbskull ./flat \\
                     --output_dir \"$results_dir\" \\
                     --threads $DEEPDIVE_NUM_PROCESSES \\
@@ -58,10 +62,10 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                     #
             " else "
                 \($deepdive.sampler.sampler_cmd) gibbs      \\
-                    --variables <(flatten ./variables  )    \\
-                    --domains   <(flatten ./domains    )    \\
-                    --factors   <(flatten ./factors    )    \\
-                    --weights   <(flatten ./$WEIGHT_DIR)    \\
+                    --variables <(flatten ./variables/)     \\
+                    --domains   <(flatten ./domains/  )     \\
+                    --factors   <(flatten ./factors/  )     \\
+                    --weights   <(flatten ./$weights/ )     \\
                     --fg_meta   ./meta                      \\
                     --outputFile \"$results_dir\"           \\
                     --n_threads $DEEPDIVE_NUM_PROCESSES     \\
@@ -69,6 +73,10 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                     \(if $deepdive.sampler.partitions > 1 then "-i 0" else "" end) \\
                     #
             " end)
+
+            # TODO maybe this database interaction for the weights after
+            # learning each shard is unnecessary if we have the sampler checkpoint
+            # them directly, and we could also keep max two copies
 
             # load weights to database
             deepdive create table \(deepdiveInferenceResultWeightsTable | @sh) \\
@@ -83,14 +91,7 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
 
             \(if $deepdive.sampler.partitions > 1 then "
                 # dump weights back out for next-shard learning or inference step
-                if [[ $pid -lt \($deepdive.sampler.partitions - 1) ]]; then
-                    # not last shard: dump for next-shard learning
-                    export TARGET_WEIGHT_DIR=\"$DEEPDIVE_FACTORGRAPH_DIR\"/$(($pid+1))/weights_hot
-                else
-                    export TARGET_WEIGHT_DIR=\"$DEEPDIVE_FACTORGRAPH_DIR\"/learned_weights
-                fi
-
-                mkdir -p \"$TARGET_WEIGHT_DIR\"
+                mkdir -p weights.learned
                 deepdive compute execute \\
                     input_sql=\(
                         { SELECT:
@@ -107,9 +108,13 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                         } | asSql | asPrettySqlArg) \\
                     command=\("
                         sampler-dw text2bin weight /dev/stdin /dev/stdout /dev/null |
-                        pbzip2 >\"$TARGET_WEIGHT_DIR\"/weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
+                        pbzip2 >weights.learned/weights.part-${DEEPDIVE_CURRENT_PROCESS_INDEX}.bin.bz2
                     " | @sh) \\
                     output_relation=
+
+                # expose the last shard's weights for the inference phase
+                [[ $pid -lt \($deepdive.sampler.partitions - 1) ]] ||
+                    ln -sfn $pid/weights.learned ../learned_weights
 
             " else "" end)
 
@@ -152,17 +157,18 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                 cd \"$fg_dir\"
 
                 # run sampler for inference with given weights without learning
-                LEARNED_WEIGHTS=\"$DEEPDIVE_FACTORGRAPH_DIR\"/learned_weights
+                ln -sfn ../learned_weights weights.to_infer
+                weights=weights.to_infer
 
                 \(if $deepdive.sampler.sampler_cmd == "numbskull" then "
                     mkdir -p ./flat
                     if [ ./meta -nt ./flat/graph.meta ]; then
-                        head -n 1 ./meta    >./flat/graph.meta
-                        flatten ./variables >./flat/graph.variables
-                        flatten ./factors   >./flat/graph.factors
-                        flatten ./domains   >./flat/graph.domains
+                        head -n 1 ./meta     >./flat/graph.meta
+                        flatten ./variables/ >./flat/graph.variables
+                        flatten ./factors/   >./flat/graph.factors
+                        flatten ./domains/   >./flat/graph.domains
                     fi
-                    flatten \"$LEARNED_WEIGHTS\" >./flat/graph.weights
+                    flatten ./$weights/ >./flat/graph.weights
                     numbskull ./flat \\
                         --output_dir \"$results_dir\" \\
                         --threads $DEEPDIVE_NUM_PROCESSES \\
@@ -171,10 +177,10 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                         #
                 " else "
                     \($deepdive.sampler.sampler_cmd) gibbs      \\
-                        --variables <(flatten ./variables)      \\
-                        --domains   <(flatten ./domains)        \\
-                        --factors   <(flatten ./factors)        \\
-                        --weights   <(flatten \"$LEARNED_WEIGHTS\") \\
+                        --variables <(flatten ./variables/)     \\
+                        --domains   <(flatten ./domains/  )     \\
+                        --factors   <(flatten ./factors/  )     \\
+                        --weights   <(flatten ./$weights/ )     \\
                         --fg_meta   ./meta                      \\
                         --outputFile \"$results_dir\"           \\
                         --n_threads $DEEPDIVE_NUM_PROCESSES     \\

--- a/inference/run-sampler
+++ b/inference/run-sampler
@@ -24,6 +24,7 @@ flatten() { find -L "$@" -type f -size +0 -exec pbzip2 -c -d -k {} +; }
 
 case $SamplerCmd in
     numbskull)
+        set -x
         mkdir -p ./flat
         if [[ ./meta -nt ./flat/graph.meta ]]; then
             head -n 1 ./meta     >./flat/graph.meta
@@ -40,13 +41,16 @@ case $SamplerCmd in
         ;;
 
     *) # assume DimmWitted-compatible command-line interface
-        $SamplerCmd gibbs \
-            --variables <(flatten ./variables/  )   \
-            --domains   <(flatten ./domains/    )   \
-            --factors   <(flatten ./factors/    )   \
-            --weights   <(flatten ./"$weights"/ )   \
+        # assemble multiple flags for multipart inputs
+        opts+=$(find -L ./variables/  -type f -size +0 | sed 's/.*/--variables <(pbzip2 -c -d -k &) \\/')
+        opts+=$(find -L ./domains/    -type f -size +0 | sed 's/.*/--domains   <(pbzip2 -c -d -k &) \\/')
+        opts+=$(find -L ./factors/    -type f -size +0 | sed 's/.*/--factors   <(pbzip2 -c -d -k &) \\/')
+        opts+=$(find -L ./"$weights"/ -type f -size +0 | sed 's/.*/--weights   <(pbzip2 -c -d -k &) \\/')
+        set -x
+        eval '$SamplerCmd gibbs \
+            '"$opts"'
             --fg_meta   ./meta                      \
             --outputFile "$results_dir"             \
             --n_threads $DEEPDIVE_NUM_PROCESSES     \
-            "$@"
+            "$@"'
 esac

--- a/inference/run-sampler
+++ b/inference/run-sampler
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# run-sampler -- Invokes DimmWitted or equivalent Gibbs sampler for learning and inference in a uniform way
+# $ cd run/model/factorgraph/0
+# $ run-sampler results_dir=... weights=... [NAME=VALUE...] -- SAMPLER_CMD [SAMPLER_ARG...]
+##
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --) shift; break ;;
+        *) declare -- "$1"; shift ;;
+    esac
+done
+
+# required parameters
+: ${DEEPDIVE_NUM_PROCESSES:?}
+: ${results_dir:?}
+: ${weights:?}
+
+[[ $# -gt 0 ]] || usage "$0" "Missing SAMPLER_CMD"
+SamplerCmd=$1; shift
+
+flatten() { find -L "$@" -type f -size +0 -exec pbzip2 -c -d -k {} +; }
+
+case $SamplerCmd in
+    numbskull)
+        mkdir -p ./flat
+        if [[ ./meta -nt ./flat/graph.meta ]]; then
+            head -n 1 ./meta     >./flat/graph.meta
+            # TODO: save disk space
+            flatten ./variables/ >./flat/graph.variables
+            flatten ./factors/   >./flat/graph.factors
+            flatten ./domains/   >./flat/graph.domains
+        fi
+        flatten ./"$weights"/    >./flat/graph.weights
+        numbskull ./flat                        \
+            --output_dir "$results_dir"         \
+            --threads $DEEPDIVE_NUM_PROCESSES   \
+            "$@"
+        ;;
+
+    *) # assume DimmWitted-compatible command-line interface
+        $SamplerCmd gibbs \
+            --variables <(flatten ./variables/  )   \
+            --domains   <(flatten ./domains/    )   \
+            --factors   <(flatten ./factors/    )   \
+            --weights   <(flatten ./"$weights"/ )   \
+            --fg_meta   ./meta                      \
+            --outputFile "$results_dir"             \
+            --n_threads $DEEPDIVE_NUM_PROCESSES     \
+            "$@"
+esac

--- a/inference/run-sampler
+++ b/inference/run-sampler
@@ -41,11 +41,20 @@ case $SamplerCmd in
         ;;
 
     *) # assume DimmWitted-compatible command-line interface
-        # assemble multiple flags for multipart inputs
-        opts+=$(find -L ./variables/  -type f -size +0 | sed 's/.*/--variables <(pbzip2 -c -d -k &) \\/')
-        opts+=$(find -L ./domains/    -type f -size +0 | sed 's/.*/--domains   <(pbzip2 -c -d -k &) \\/')
-        opts+=$(find -L ./factors/    -type f -size +0 | sed 's/.*/--factors   <(pbzip2 -c -d -k &) \\/')
-        opts+=$(find -L ./"$weights"/ -type f -size +0 | sed 's/.*/--weights   <(pbzip2 -c -d -k &) \\/')
+        mk_process_substitution_opts() {
+            # list of file paths should evenly spread into the degree of parallelism
+            split -n r/$DEEPDIVE_NUM_PROCESSES --filter '
+                    sed "s/\$/ \\\\/" |
+                    printf "%s\n" "'"$1"' <(pbzip2 -c -d -k \\" "$(cat)" ") \\"
+                '
+            echo
+        }
+        # assemble many flags for multipart inputs to load them in parallel
+        opts=
+        opts+=$(find -L ./variables/  -type f -size +0 | mk_process_substitution_opts --variables)
+        opts+=$(find -L ./domains/    -type f -size +0 | mk_process_substitution_opts --domains  )
+        opts+=$(find -L ./factors/    -type f -size +0 | mk_process_substitution_opts --factors  )
+        opts+=$(find -L ./"$weights"/ -type f -size +0 | mk_process_substitution_opts --weights  )
         set -x
         eval '$SamplerCmd gibbs \
             '"$opts"'

--- a/stage.sh
+++ b/stage.sh
@@ -141,6 +141,7 @@ generate-wrapper-for-libdirs          "$STAGE_DIR"/util/sampler-$cmd \
                                       "$STAGE_DIR"/lib/dw
 done
 stage inference/deepdive-model                                    util/
+stage inference/run-sampler                                       util/
 
 # Stanford CoreNLP utilities
 stage util/nlp/deepdive-corenlp                                   util/


### PR DESCRIPTION
with some compiler refactoring, e.g., moving sampler invocation details out of compiler into `inference/run-sampler`.

I'm still a little confused how the partitioning plays nicely with `deepdive model weights reuse`, but the main workflow should work as before.