### PR TITLE
Make gpfdist work

### DIFF
--- a/compiler/compile-config/compile-config-2.01-grounding
+++ b/compiler/compile-config/compile-config-2.01-grounding
@@ -498,9 +498,9 @@ def factorWeightDescriptionSqlExpr:
                     echo \(
                     { SELECT:
                         [ ( .function_.variables[]
-                        | { expr: "f.\(.columnId | asSqlIdent) & ((1::bigint << 48) - 1)"} )
+                        | { alias: .columnId, expr: "f.\(.columnId | asSqlIdent) & ((1::bigint << 48) - 1)"} )
                         , ( .function_.variables[]
-                        | { table: "C\(.ordinal)", column: "cid" } )
+                        | { alias: "cid_\(.ordinal)", table: "C\(.ordinal)", column: "cid" } )
                         , { alias: "weight_id", table: "w", column: "wid" }
                         , { alias: "feature_value", table: "f", column: "feature_value" }
                         ]
@@ -589,8 +589,8 @@ def factorWeightDescriptionSqlExpr:
                     # dump weights with initvalue from previously learned ones
                     { SELECT:
                         [ { table: "w", column: "wid" }
-                        , { expr: "CASE WHEN w.isfixed THEN 1 ELSE 0 END" }
-                        , { expr: "COALESCE(reuse.weight, w.initvalue, 0)" }
+                        , { alias: "isfixed", expr: "CASE WHEN w.isfixed THEN 1 ELSE 0 END" }
+                        , { alias: "value", expr: "COALESCE(reuse.weight, w.initvalue, 0)" }
                         ]
                     , FROM: [ { alias: "w", table: .weightsTable } ]
                     , JOIN: { LEFT_OUTER: { alias: "reuse", table: deepdiveReuseWeightsTable }
@@ -604,8 +604,8 @@ def factorWeightDescriptionSqlExpr:
                     # dump weights from scratch
                     { SELECT:
                         [ { column: "wid" }
-                        , { expr: "CASE WHEN isfixed THEN 1 ELSE 0 END" }
-                        , { expr: "COALESCE(initvalue, 0)" }
+                        , { alias: "isfixed", expr: "CASE WHEN isfixed THEN 1 ELSE 0 END" }
+                        , { alias: "value", expr: "COALESCE(initvalue, 0)" }
                         ]
                     , FROM: [ { table: .weightsTable } ]
                     } | asSql | asPrettySqlArg)

--- a/database/db-driver/greenplum/db-unload
+++ b/database/db-driver/greenplum/db-unload
@@ -56,6 +56,7 @@ case $format in
             }
             trap cleanup EXIT
 
+            gpfdist --help &>/dev/null ||  { echo 'gpfdist not working! make it work!'; }
             STEP "starting $nsinks gpfdist processes"
             # spawn gpfdist processes
             locations=()

--- a/database/db-driver/greenplum/db-unload
+++ b/database/db-driver/greenplum/db-unload
@@ -56,7 +56,7 @@ case $format in
             }
             trap cleanup EXIT
 
-            gpfdist --help &>/dev/null ||  { echo 'gpfdist not working! make it work!'; }
+            gpfdist --help &>/dev/null ||  { echo 'gpfdist not working! make it work!'; exit 1; }
             STEP "starting $nsinks gpfdist processes"
             # spawn gpfdist processes
             locations=()


### PR DESCRIPTION
Fixes two issues:
1. An unload query with ambiguous columns (including duplicate `cid`s and `?column?`s) would break gpfdist.
2. `deepdive compute execute` hangs indefinitely if spawned `gpfdist` command fails.