### PR TITLE
Fix jq load_probabilities precision error using python

### DIFF
--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -197,10 +197,11 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
                 cd \"$DEEPDIVE_RESULTS_DIR\"/$pid
                 cat inference_result.out.text |
                 # restoring shard ID to the vids
-                jq -R -r --argjson SHARD_BASE $(($pid << 48)) '
-                    split(\" \") |
-                    [ (.[0] | tonumber + $SHARD_BASE | tostring)
-                    , .[1:][] ] | join(\"\\t\")' |
+                python3 -c "
+import sys
+for line in sys.stdin:
+  vid, cid, prob = line.split(); print('\t'.join([str(int(vid) + ($SHARD_BASE << 48)), cid, prob]))
+" |
                 DEEPDIVE_LOAD_FORMAT=tsv \\
                 deepdive load \(deepdiveInferenceResultVariablesTable | @sh) /dev/stdin
             done

--- a/compiler/compile-config/compile-config-2.02-learning_inference
+++ b/compiler/compile-config/compile-config-2.02-learning_inference
@@ -196,12 +196,7 @@ if .deepdive_.execution.processes | has("process/grounding/combine_factorgraph")
             for pid in $DEEPDIVE_FACTORGRAPH_SHARDS; do
                 cd \"$DEEPDIVE_RESULTS_DIR\"/$pid
                 cat inference_result.out.text |
-                # restoring shard ID to the vids
-                python3 -c "
-import sys
-for line in sys.stdin:
-  vid, cid, prob = line.split(); print('\t'.join([str(int(vid) + ($SHARD_BASE << 48)), cid, prob]))
-" |
+                pid=$pid deepdive env restore_partitioned_vids |
                 DEEPDIVE_LOAD_FORMAT=tsv \\
                 deepdive load \(deepdiveInferenceResultVariablesTable | @sh) /dev/stdin
             done

--- a/inference/restore_partitioned_vids
+++ b/inference/restore_partitioned_vids
@@ -1,0 +1,7 @@
+#!/usr/bin/perl -w
+use strict;
+my $SHARD_BASE = $ENV{pid} << 48;
+while (<>) {
+    my ($vid, @rest) = split(" ");
+    print join("\t", ($SHARD_BASE | $vid), @rest), "\n";
+}

--- a/stage.sh
+++ b/stage.sh
@@ -142,6 +142,7 @@ generate-wrapper-for-libdirs          "$STAGE_DIR"/util/sampler-$cmd \
 done
 stage inference/deepdive-model                                    util/
 stage inference/run-sampler                                       util/
+stage inference/restore_partitioned_vids                          util/
 
 # Stanford CoreNLP utilities
 stage util/nlp/deepdive-corenlp                                   util/


### PR DESCRIPTION
`jq` has a precision bug while loading probabilities with big vids, due to a known issue that it's using double floating numbers to store integers. There seems no good way in jq to support better precision:
https://github.com/stedolan/jq/issues/369

We've tried using awk with --bignum but versioning seems a problem.

Here we just try to use python3 to do the job.
