### PR TITLE
DeepDive dependencises

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -8,6 +8,13 @@ INSTALLER_HOME_DIR=$(dirname "$0")/install
 running_from_git=true; [[ -e "$INSTALLER_HOME_DIR"/../../.git ]] || running_from_git=false
 has() { type "$@"; } &>/dev/null
 error() { echo "$@"; false; } >&2
+enter() {
+    local name=$1
+    local desc=${2:-$name}
+    local value=${!name:-}
+    read -p "Enter $desc ${value:+[$value]}: "
+    eval "$name=\${REPLY:-\${$name:-}}"
+}
 
 # common installers ###########################################################
 install_deepdive_build_deps() { false; }

--- a/util/install/README.md
+++ b/util/install/README.md
@@ -1,0 +1,26 @@
+# DeepDive Installer Scripts
+
+## Layout of an Installer Script
+
+Shell functions whose name starts with `install_`.
+
+```bash
+install_deepdive_runtime_deps() {
+    ...
+}
+
+install_postgres() {
+    ...
+}
+
+...
+```
+
+## Utilities
+Several utility functions are available to the installer scripts.
+
+* `error "Cannot install dependencies without Homebrew (http://brew.sh)"`
+* `source_script install.Ubuntu.sh`
+* `source_os_script pgxl`
+* `enter NUM_DATA_NODES "number of data nodes"`
+

--- a/util/install/install.Ubuntu.pgxl.sh
+++ b/util/install/install.Ubuntu.pgxl.sh
@@ -39,12 +39,9 @@ TARGET_DIR=/opt/pgxl
 ###################################################
 
 # ask for confirmation of key settings
-read -p "Enter number of data nodes [$NUM_DATA_NODES]: " CUSTOM_NUM_DATA_NODES
-NUM_DATA_NODES=${CUSTOM_NUM_DATA_NODES:-$NUM_DATA_NODES}
-read -p "Enter data dir to hold segment data [$DATA_DIR]: " CUSTOM_DATA_DIR
-DATA_DIR=${CUSTOM_DATA_DIR:-$DATA_DIR}
-read -p "Enter port number [$USER_DB_PORT]: " CUSTOM_USER_DB_PORT
-USER_DB_PORT=${CUSTOM_USER_DB_PORT:-$USER_DB_PORT}
+enter NUM_DATA_NODES "number of data nodes"
+enter DATA_DIR       "data dir to hold segment data"
+enter USER_DB_PORT   "port number"
 
 sudo apt-get update
 sudo apt-get -y install -y screen curl git rsync openssl locales openssh-server openssh-client


### PR DESCRIPTION
CHANGE in install_deepdive_runtime_deps and deepdive :

sudo apt-get install -qy software-properties-common python-software-properties
to
sudo apt-get install -qy software-properties-common

because in Ubuntu 20.04 python-software-properties doesn't work which cause error when I install deepdive runtime dependencies and so it's stop the whole process of downloading. 